### PR TITLE
test: add component type mismatch regression

### DIFF
--- a/slynx/component_type_mismatch.slynx
+++ b/slynx/component_type_mismatch.slynx
@@ -1,0 +1,13 @@
+component A {
+    pub prop value: int = 1;
+}
+
+component B {
+    pub prop value: str = "text";
+}
+
+component Holder {
+    pub prop item: A = B {};
+}
+
+func main(): Component -> Holder {};

--- a/tests/component_type_mismatch.rs
+++ b/tests/component_type_mismatch.rs
@@ -1,0 +1,19 @@
+use std::{path::PathBuf, sync::Arc};
+
+use slynx::compiler::js::WebCompiler;
+
+#[test]
+fn test_component_type_mismatch_errors() {
+    // SavioCodes | 2026-02-28 14:26 (America/Sao_Paulo)
+    // Regression test: assigning B into prop typed as A must fail type checking.
+    let context = slynx::SlynxContext::new(Arc::new(PathBuf::from(
+        "slynx/component_type_mismatch.slynx",
+    )))
+    .unwrap();
+
+    let result = context.start_compilation(WebCompiler::new());
+    assert!(
+        result.is_err(),
+        "Expected type checker to reject incompatible component assignment",
+    );
+}


### PR DESCRIPTION
## Description
Adds a regression test for component type mismatch (`A` assigned with `B`) to keep this behavior covered.
This PR is intentionally test-only to avoid overlap with the type-checker refactor fixes.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Changes Made
- Added test fixture: `slynx/component_type_mismatch.slynx`
- Added regression test: `tests/component_type_mismatch.rs`
- Kept this PR scoped to tests only

## Testing
How has this been tested?
- [ ] Unit tests
- [x] Integration tests
- [ ] Manual testing

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run `cargo fmt`
- [ ] I have run `cargo clippy`

## Related Issues

