### PR TITLE
Feat/numeric separator

### DIFF
--- a/frontend/src/lexer/mod.rs
+++ b/frontend/src/lexer/mod.rs
@@ -186,15 +186,27 @@ impl Lexer {
                     let mut buffer = String::new();
                     let start = idx;
                     let mut float_value = false;
-
+                    let mut last_is_underscore = false;
+                    let mut should_err = false;
                     while let Some(c) = chars.get(idx)
                         && (c.is_ascii_digit() || *c == '.' || *c == '_')
                     {
                         if *c == '.' {
                             float_value = true;
                         }
+                        if *c == '_' && last_is_underscore {
+                            should_err = true;
+                        }
+                        last_is_underscore = *c == '_';
                         buffer.push(*c);
                         idx += 1;
+                    }
+                    if should_err || buffer.ends_with("_") {
+                        return Err(LexerError::MalformedNumber {
+                            number: buffer,
+                            init: start,
+                            end: idx,
+                        });
                     }
                     idx -= 1;
                     let buffer = buffer.replace('_', "");

--- a/frontend/src/lexer/mod.rs
+++ b/frontend/src/lexer/mod.rs
@@ -186,8 +186,9 @@ impl Lexer {
                     let mut buffer = String::new();
                     let start = idx;
                     let mut float_value = false;
+
                     while let Some(c) = chars.get(idx)
-                        && (c.is_ascii_digit() || *c == '.')
+                        && (c.is_ascii_digit() || *c == '.' || *c == '_')
                     {
                         if *c == '.' {
                             float_value = true;
@@ -196,6 +197,7 @@ impl Lexer {
                         idx += 1;
                     }
                     idx -= 1;
+                    let buffer = buffer.replace('_', "");
                     if float_value {
                         match buffer.parse::<f32>() {
                             Ok(value) => Token::float(value, start, idx),

--- a/frontend/src/lexer/mod.rs
+++ b/frontend/src/lexer/mod.rs
@@ -187,6 +187,7 @@ impl Lexer {
                     let start = idx;
                     let mut float_value = false;
                     let mut last_is_underscore = false;
+                    let mut last_is_dot = false;
                     let mut should_err = false;
                     while let Some(c) = chars.get(idx)
                         && (c.is_ascii_digit() || *c == '.' || *c == '_')
@@ -194,9 +195,11 @@ impl Lexer {
                         if *c == '.' {
                             float_value = true;
                         }
-                        if *c == '_' && last_is_underscore {
+                        if (*c == '.' && last_is_dot) || (*c == '_' && last_is_underscore) {
                             should_err = true;
                         }
+
+                        last_is_dot = *c == '.';
                         last_is_underscore = *c == '_';
                         buffer.push(*c);
                         idx += 1;

--- a/slynx/booleans.slynx
+++ b/slynx/booleans.slynx
@@ -1,5 +1,5 @@
 func is_way_bigger(n: int, m:int):bool {
-	m < n && n > m / 2_000_0_0_0.44_00_2
+	m < n && n > m / 2_000_0_0_0
 }
 
 func is_bigger(n:int, m:int):bool->m-1 > n * 2 || m > 0;

--- a/slynx/booleans.slynx
+++ b/slynx/booleans.slynx
@@ -1,5 +1,5 @@
 func is_way_bigger(n: int, m:int):bool {
-	m < n && n > m / 2
+	m < n && n > m / 2_000_00
 }
 
 func is_bigger(n:int, m:int):bool->m-1 > n * 2 || m > 0;

--- a/slynx/booleans.slynx
+++ b/slynx/booleans.slynx
@@ -1,5 +1,5 @@
 func is_way_bigger(n: int, m:int):bool {
-	m < n && n > m / 2_000_00
+	m < n && n > m / 2_000_0_0_0
 }
 
 func is_bigger(n:int, m:int):bool->m-1 > n * 2 || m > 0;

--- a/slynx/booleans.slynx
+++ b/slynx/booleans.slynx
@@ -1,5 +1,5 @@
 func is_way_bigger(n: int, m:int):bool {
-	m < n && n > m / 2_000_0_0_0
+	m < n && n > m / 2_000_0_0_0.44_00_2
 }
 
 func is_bigger(n:int, m:int):bool->m-1 > n * 2 || m > 0;


### PR DESCRIPTION
## Summary
This PR implements numeric separators such as 1_000_000_000

## Scope

- Modified lexer to support separators
- Also made lexer error on numerics such as 4..0 

## Validation

```bash
# example
make test
cargo clippy
```

## Documentation Impact

- [x] No documentation changes were needed
- [ ] I updated the relevant documentation

## Checklist

- [x] My change is focused and reviewable
- [x] I performed a self-review
- [x] I added comments only where they help explain non-obvious logic
- [x] I added or updated tests when applicable
- [x] I ran the validation listed above
- [ ] I used the existing issue/PR templates where applicable

## Related Issues
N/A