### PR TITLE
feat: add sugestion basic for erros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "color-eyre",
+ "common",
  "frontend",
  "middleend",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.5.52", features = ["derive"] }
 color-eyre={workspace=true}
 middleend = {path="./middleend"}
 frontend = {path="./frontend"}
-
+common = {path="./common"}
 [workspace]
 members = [
   ".",

--- a/src/context.rs
+++ b/src/context.rs
@@ -15,6 +15,10 @@ use frontend::lexer::{Lexer, error::LexerError};
 use frontend::parser::{Parser, error::ParseError};
 use middleend::{IRError, SlynxIR};
 
+use crate::err::{
+    SlynxSuggestion, suggestions_from_hir, suggestions_from_ir, suggestions_from_lexer,
+    suggestions_from_parser, suggestions_from_type_error,
+};
 #[derive(Debug)]
 ///The type of the error that was generated
 pub enum SlynxErrorType {
@@ -46,6 +50,7 @@ pub struct SlynxError {
     ///The file path the error occuried
     file: String,
     source_code: String,
+    suggestion: Vec<SlynxSuggestion>,
 }
 impl std::error::Error for SlynxError {}
 
@@ -107,7 +112,11 @@ impl std::fmt::Display for SlynxError {
             self.file.bold()
         )?;
         writeln!(f, "{}", error_with_data)?;
-        writeln!(f, "{}", error_points)
+        writeln!(f, "{}", error_points)?;
+        for suggestion in self.suggestion.iter() {
+            writeln!(f, "-->{}", suggestion)?;
+        }
+        writeln!(f)
     }
 }
 
@@ -220,6 +229,7 @@ impl SlynxContext {
                 declarations_module,
             ),
             file: self.file_name(),
+            suggestion: suggestions_from_ir(error),
             source_code,
         }
     }
@@ -228,51 +238,59 @@ impl SlynxContext {
     pub fn compile(self) -> Result<CompilationOutput> {
         let stream = match Lexer::tokenize(self.get_entry_point_source()) {
             Ok(value) => value,
-            Err(e) => match e {
-                LexerError::MalformedNumber { init, .. } => {
-                    let (line, column, src) = self.get_line_info(&self.entry_point, init);
-                    let err = SlynxError {
-                        line,
-                        ty: SlynxErrorType::Lexer,
-                        column_start: column,
-                        message: e.to_string(),
-                        file: self.entry_point.to_string_lossy().to_string(),
-                        source_code: src.to_string(),
-                    };
-                    return Err(Report::new(err));
+            Err(e) => {
+                let suggestion = suggestions_from_lexer(&e);
+                match e {
+                    LexerError::MalformedNumber { init, .. } => {
+                        let (line, column, src) = self.get_line_info(&self.entry_point, init);
+                        let err = SlynxError {
+                            line,
+                            ty: SlynxErrorType::Lexer,
+                            column_start: column,
+                            message: e.to_string(),
+                            suggestion,
+                            file: self.entry_point.to_string_lossy().to_string(),
+                            source_code: src.to_string(),
+                        };
+                        return Err(Report::new(err));
+                    }
+                    LexerError::UnrecognizedChar { index, .. } => {
+                        let (line, column, src) = self.get_line_info(&self.entry_point, index);
+                        let err = SlynxError {
+                            line,
+                            ty: SlynxErrorType::Lexer,
+                            column_start: column,
+                            message: e.to_string(),
+                            suggestion,
+                            file: self.entry_point.to_string_lossy().to_string(),
+                            source_code: src.to_string(),
+                        };
+                        return Err(Report::new(err));
+                    }
                 }
-                LexerError::UnrecognizedChar { index, .. } => {
-                    let (line, column, src) = self.get_line_info(&self.entry_point, index);
-                    let err = SlynxError {
-                        line,
-                        ty: SlynxErrorType::Lexer,
-                        column_start: column,
-                        message: e.to_string(),
-                        file: self.entry_point.to_string_lossy().to_string(),
-                        source_code: src.to_string(),
-                    };
-                    return Err(Report::new(err));
-                }
-            },
+            }
         };
         let decls = match Parser::new(stream).parse_declarations() {
             Ok(v) => v,
             Err(e) => {
                 return match e.downcast_ref::<ParseError>() {
-                    Some(ref err @ ParseError::UnexpectedToken(token, _)) => {
+                    Some(err @ ParseError::UnexpectedToken(token, _)) => {
                         let (line, column, src) =
                             self.get_line_info(&self.entry_point, token.span.start);
+                        let suggestion = suggestions_from_parser(err);
                         let err = SlynxError {
                             line,
                             ty: SlynxErrorType::Parser,
                             column_start: column,
                             message: err.to_string(),
                             file: self.file_name(),
+                            suggestion,
                             source_code: src.to_string(),
                         };
                         Err(e.wrap_err(err))
                     }
-                    Some(ParseError::UnexpectedEndOfInput) => {
+                    Some(err @ ParseError::UnexpectedEndOfInput) => {
+                        let suggestion = suggestions_from_parser(err);
                         let (line, column, src) = self.get_line_info(
                             &self.entry_point,
                             self.lines.get(&self.entry_point).unwrap().len().max(1) - 1,
@@ -283,6 +301,7 @@ impl SlynxContext {
                             column_start: column,
                             message: e.to_string(),
                             file: self.file_name(),
+                            suggestion,
                             source_code: src.to_string(),
                         };
                         Err(e.wrap_err(err))
@@ -295,12 +314,14 @@ impl SlynxContext {
         if let Err(e) = hir.generate(decls) {
             match e.downcast_ref::<HIRError>() {
                 Some(err) => {
+                    let suggestion = suggestions_from_hir(err);
                     let (line, column, src) = self.get_line_info(&self.entry_point, err.span.start);
                     let err = SlynxError {
                         line,
                         column_start: column,
                         ty: SlynxErrorType::Hir,
                         message: e.to_string(),
+                        suggestion,
                         file: self.entry_point.to_string_lossy().to_string(),
                         source_code: src.to_string(),
                     };
@@ -312,10 +333,12 @@ impl SlynxContext {
         let types_module = match TypeChecker::check(&mut hir) {
             Err(e) => match e.downcast_ref::<TypeError>() {
                 Some(err) => {
+                    let suggestion = suggestions_from_type_error(err);
                     let (line, column, src) = self.get_line_info(&self.entry_point, err.span.start);
                     let err = SlynxError {
                         line,
                         column_start: column,
+                        suggestion,
                         ty: SlynxErrorType::Type,
                         message: e.to_string(),
                         file: self.file_name(),

--- a/src/err.rs
+++ b/src/err.rs
@@ -1,0 +1,234 @@
+use std::fmt;
+
+use frontend::{
+    checker::error::{TypeError, TypeErrorKind},
+    hir::error::{HIRError, HIRErrorKind},
+    lexer::error::LexerError,
+    parser::error::ParseError,
+};
+use middleend::IRError;
+
+#[derive(Debug, PartialEq)]
+pub enum SlynxSuggestion {
+    /// this error is raised when the Typeckeck
+    IncompatibleTypes(String, String),
+    CannotCastType(String, String),
+    CiclicType(String),
+    IncompatibleComponent(String),
+    InvalidFuncallArgLength(String, String),
+    NotARef(String, String),
+    /// this error is raised when the lexer
+    UnrecognizedChar(String, String),
+    MalformedNumber(String, String, String),
+    UnexpectedToken(String, String),
+    NameAlreadyDefined(String),
+    IRTypeNotRecognized(String),
+    DeclarationNotRecognized(String),
+}
+impl fmt::Display for SlynxSuggestion {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SlynxSuggestion::IncompatibleTypes(received, expected) => write!(
+                f,
+                "expected `{expected}`, but got `{received}` — consider explicitly converting the value to `{expected}`"
+            ),
+            SlynxSuggestion::CannotCastType(received, expected) => write!(
+                f,
+                "`{received}` cannot be cast to `{expected}` — there is no known conversion between these two types"
+            ),
+            SlynxSuggestion::CiclicType(type_name) => write!(
+                f,
+                "type `{type_name}` refers to itself, which creates an infinite cycle — try breaking the cycle with indirection"
+            ),
+            SlynxSuggestion::IncompatibleComponent(expected) => write!(
+                f,
+                "this value is not a valid component — it must satisfy `{expected}`"
+            ),
+            SlynxSuggestion::InvalidFuncallArgLength(received, expected) => write!(
+                f,
+                "this function expects {expected} argument(s), but {received} were provided"
+            ),
+            SlynxSuggestion::NotARef(received, expected) => write!(
+                f,
+                "expected a reference to `{expected}`, but got `{received}` — try passing a reference instead"
+            ),
+            SlynxSuggestion::UnrecognizedChar(char, index) => write!(
+                f,
+                "the character `{char}` at position {index} is not valid here — remove or replace it"
+            ),
+            SlynxSuggestion::MalformedNumber(number, init, end) => write!(
+                f,
+                "`{number}` is not a valid number literal (problem near positions {init}–{end}) — check for invalid characters or incorrect formatting"
+            ),
+            SlynxSuggestion::UnexpectedToken(token, expected) => {
+                write!(f, "unexpected `{token}` — expected {expected} here")
+            }
+            SlynxSuggestion::NameAlreadyDefined(name) => write!(
+                f,
+                "`{name}` is already defined in this scope — use a different name or remove the duplicate definition"
+            ),
+            SlynxSuggestion::IRTypeNotRecognized(type_) => write!(
+                f,
+                "internal compiler error: type `{type_}` was not registered in the IR — this is likely a compiler bug, please report it"
+            ),
+            SlynxSuggestion::DeclarationNotRecognized(decl) => write!(
+                f,
+                "internal compiler error: declaration `{decl}` was not registered in the IR — this is likely a compiler bug, please report it"
+            ),
+        }
+    }
+}
+/// this function converts a [`TypeError`] into a [`Vec<SlynxSuggestion>`]
+pub fn suggestions_from_type_error(err: &TypeError) -> Vec<SlynxSuggestion> {
+    match &err.kind {
+        TypeErrorKind::IncompatibleTypes { expected, received } => {
+            vec![SlynxSuggestion::IncompatibleTypes(
+                format!("{:?}", received),
+                format!("{:?}", expected),
+            )]
+        }
+        TypeErrorKind::CannotCastType { expected, received } => {
+            vec![SlynxSuggestion::CannotCastType(
+                format!("{:?}", received),
+                format!("{:?}", expected),
+            )]
+        }
+        TypeErrorKind::CiclicType { ty } => vec![SlynxSuggestion::CiclicType(format!("{:?}", ty))],
+        TypeErrorKind::IncompatibleComponent { reason } => {
+            vec![SlynxSuggestion::IncompatibleComponent(format!(
+                "{:?}",
+                reason
+            ))]
+        }
+        TypeErrorKind::InvalidFuncallArgLength {
+            expected_length,
+            received_length,
+        } => vec![SlynxSuggestion::InvalidFuncallArgLength(
+            format!("{}", received_length),
+            format!("{}", expected_length),
+        )],
+        TypeErrorKind::NotARef(a, b) => vec![SlynxSuggestion::NotARef(
+            format!("{:?}", a),
+            format!("{:?}", b),
+        )],
+        _ => vec![],
+    }
+}
+/// this function converts a [`LexerError`] into a [`Vec<SlynxSuggestion>`]
+pub fn suggestions_from_lexer(err: &LexerError) -> Vec<SlynxSuggestion> {
+    match &err {
+        LexerError::UnrecognizedChar { char, index } => vec![SlynxSuggestion::UnrecognizedChar(
+            format!("{}", char),
+            index.to_string(),
+        )],
+        LexerError::MalformedNumber { number, init, end } => {
+            vec![SlynxSuggestion::MalformedNumber(
+                number.clone(),
+                init.to_string(),
+                end.to_string(),
+            )]
+        }
+    }
+}
+/// this function converts a [`ParseError`] into a [`Vec<SlynxSuggestion>`]
+pub fn suggestions_from_parser(err: &ParseError) -> Vec<SlynxSuggestion> {
+    match &err {
+        ParseError::UnexpectedToken(token, expected) => vec![SlynxSuggestion::UnexpectedToken(
+            format!("{}", token),
+            expected.to_string(),
+        )],
+        _ => vec![],
+    }
+}
+
+/// this function converts a [`HIRError`] into a [`Vec<SlynxSuggestion>`]
+pub fn suggestions_from_hir(err: &HIRError) -> Vec<SlynxSuggestion> {
+    match &err.kind {
+        HIRErrorKind::NameAlreadyDefined(name) => {
+            vec![SlynxSuggestion::NameAlreadyDefined(name.clone())]
+        }
+        _ => vec![],
+    }
+}
+/// this function converts a [`IRError`] into a [`Vec<SlynxSuggestion>`]
+pub fn suggestions_from_ir(err: &IRError) -> Vec<SlynxSuggestion> {
+    match &err {
+        IRError::DeclarationNotRecognized(sla) => vec![SlynxSuggestion::DeclarationNotRecognized(
+            format!("{}", sla.as_raw()),
+        )],
+        _ => vec![],
+    }
+}
+/// tests for [`suggestions_from_ir`]
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    use frontend::{
+        hir::{
+            DeclarationId,
+            error::{HIRError, HIRErrorKind},
+        },
+        lexer::tokens::{Token, TokenKind},
+    };
+
+    #[test]
+    /// tests that [`suggestions_from_hir`] returns [`SlynxSuggestion::NameAlreadyDefined`] for [`HIRErrorKind::NameAlreadyDefined`]
+    fn test_suggestions_from_hir_name_already_defined() {
+        let err = HIRError {
+            kind: HIRErrorKind::NameAlreadyDefined("foo".to_string()),
+            span: common::Span { start: 0, end: 3 },
+        };
+
+        let result = suggestions_from_hir(&err);
+        assert_eq!(
+            result,
+            vec![SlynxSuggestion::NameAlreadyDefined("foo".to_string())]
+        );
+    }
+    #[test]
+    /// tests that [`suggestions_from_parser`] returns [`SlynxSuggestion::UnexpectedToken`] for [`ParseError::UnexpectedToken`]
+    fn test_suggestions_parser() {
+        let token = Token {
+            kind: TokenKind::Identifier("foo".to_string()),
+            span: common::Span { start: 0, end: 3 },
+        };
+        let err = ParseError::UnexpectedToken(token, "sla".to_string());
+        let result = suggestions_from_parser(&err);
+        assert_eq!(
+            result,
+            vec![SlynxSuggestion::UnexpectedToken(
+                "'foo'".to_string(),
+                "sla".to_string()
+            )]
+        );
+    }
+    #[test]
+    /// tests that [`suggestions_from_lexer`] returns [`SlynxSuggestion::UnrecognizedChar`] for [`LexerError::UnrecognizedChar`]
+    fn test_suggestions_lexer() {
+        let err = LexerError::UnrecognizedChar {
+            char: 'a',
+            index: 0,
+        };
+        let result = suggestions_from_lexer(&err);
+        assert_eq!(
+            result,
+            vec![SlynxSuggestion::UnrecognizedChar(
+                "a".to_string(),
+                "0".to_string()
+            )]
+        );
+    }
+    #[test]
+    /// tests that [`suggestions_from_ir`] returns [`SlynxSuggestion::DeclarationNotRecognized`] for [`IRError::DeclarationNotRecognized`]
+    fn test_suggestions_ir() {
+        let id = DeclarationId::from_raw(42);
+        let err = IRError::DeclarationNotRecognized(id);
+        let result = suggestions_from_ir(&err);
+        assert_eq!(
+            result,
+            vec![SlynxSuggestion::DeclarationNotRecognized("42".to_string())]
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ pub use frontend::hir;
 pub use frontend::lexer;
 pub use frontend::parser;
 
+pub mod err;
+pub use err::*;
+
 pub use middleend;
 use middleend::*;
 


### PR DESCRIPTION
## Summary
This PR introduces the src/err.rs module, which maps raw compiler errors (from the Lexer, Parser, HIR, TypeChecker, and IR) into user-friendly suggestions. This significantly improves the developer experience by not only highlighting where an error occurred but also why it happened and how it might be resolved.

## Scope

- Added: SlynxSuggestion enum to categorize error types.
- Added: fmt::Display implementation for SlynxSuggestion to provide human-readable advice.
- Added: Helper functions (suggestions_from_...) to bridge internal errors to user-facing suggestions.

## Validation

List the commands, tests, or manual checks you ran.

```bash
# example
cargo test
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
```

## Documentation Impact

- [X] No documentation changes were needed
- [ ] I updated the relevant documentation

## Checklist

- [X] My change is focused and reviewable
- [X] I performed a self-review
- [X] I added comments only where they help explain non-obvious logic
- [X] I added or updated tests when applicable
- [X] I ran the validation listed above
- [ ] I used the existing issue/PR templates where applicable

## Related Issues

