### PR TITLE
feat: add type tuples

### DIFF
--- a/common/src/ast/expression.rs
+++ b/common/src/ast/expression.rs
@@ -23,6 +23,11 @@ pub enum ASTExpressionKind {
     IntLiteral(i32),
     StringLiteral(String),
     FloatLiteral(f32),
+    Tuple(Vec<ASTExpression>),
+    TupleAccess {
+        tuple: Box<ASTExpression>,
+        index: usize,
+    },
     Boolean(bool),
     Binary {
         lhs: Box<ASTExpression>,

--- a/frontend/src/checker/expr.rs
+++ b/frontend/src/checker/expr.rs
@@ -1,5 +1,3 @@
-use std::num::TryFromIntError;
-
 use color_eyre::eyre::Result;
 
 use super::TypeChecker;

--- a/frontend/src/checker/expr.rs
+++ b/frontend/src/checker/expr.rs
@@ -276,6 +276,9 @@ impl TypeChecker {
         let expected = expr.ty;
 
         let calc = match expr.kind {
+            HirExpressionKind::Tuple(_) => {
+                todo!()
+            }
             HirExpressionKind::If {
                 ref mut condition,
                 ref mut else_branch,
@@ -376,6 +379,9 @@ impl TypeChecker {
     ///Sets the default type on the provided `expr`
     pub(super) fn default_expr(&mut self, expr: &mut HirExpression) -> Result<()> {
         match expr.kind {
+            HirExpressionKind::Tuple(_) => {
+                todo!()
+            }
             HirExpressionKind::If {
                 ref mut condition,
                 ref mut then_branch,

--- a/frontend/src/checker/expr.rs
+++ b/frontend/src/checker/expr.rs
@@ -1,3 +1,5 @@
+use std::num::TryFromIntError;
+
 use color_eyre::eyre::Result;
 
 use super::TypeChecker;
@@ -276,8 +278,12 @@ impl TypeChecker {
         let expected = expr.ty;
 
         let calc = match expr.kind {
-            HirExpressionKind::Tuple(_) => {
-                todo!()
+            HirExpressionKind::Tuple(ref mut fields) => {
+                let field_types = fields
+                    .iter_mut()
+                    .map(|f| self.get_type_of_expr(f))
+                    .collect::<Result<Vec<_>>>()?;
+                self.types_module.add_tuple_type(field_types)
             }
             HirExpressionKind::If {
                 ref mut condition,
@@ -379,8 +385,16 @@ impl TypeChecker {
     ///Sets the default type on the provided `expr`
     pub(super) fn default_expr(&mut self, expr: &mut HirExpression) -> Result<()> {
         match expr.kind {
-            HirExpressionKind::Tuple(_) => {
-                todo!()
+            HirExpressionKind::Tuple(ref mut fields) => {
+                let types = fields
+                    .iter_mut()
+                    .map(|f| {
+                        self.default_expr(f)?;
+                        Ok(f.ty)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                let tuple_ty = self.types_module.add_tuple_type(types);
+                expr.ty = self.unify(&tuple_ty, &expr.ty, &expr.span)?;
             }
             HirExpressionKind::If {
                 ref mut condition,

--- a/frontend/src/checker/mod.rs
+++ b/frontend/src/checker/mod.rs
@@ -232,6 +232,27 @@ impl TypeChecker {
                             Ok(*a)
                         }
                     }
+                    (HirType::Tuple { fields: f1 }, HirType::Tuple { fields: f2 }) => {
+                        if f1.len() != f2.len() {
+                            Err(TypeError {
+                                kind: TypeErrorKind::IncompatibleTypes {
+                                    expected: concrete_a,
+                                    received: concrete_b,
+                                },
+                                span: span.clone(),
+                            }
+                            .into())
+                        } else {
+                            let mut new_fields = Vec::with_capacity(f1.len());
+
+                            for (t1, t2) in f1.iter().zip(f2.iter()) {
+                                let unified = self.unify(t1, t2, span)?;
+                                new_fields.push(unified);
+                            }
+
+                            Ok(self.types_module.add_tuple_type(new_fields))
+                        }
+                    }
                     (HirType::VarReference(rf1), HirType::VarReference(rf2)) => {
                         let Some(rf1) = self.types_module.get_variable(rf1).cloned() else {
                             unreachable!("Variable should have already been declared")

--- a/frontend/src/hir/definitions.rs
+++ b/frontend/src/hir/definitions.rs
@@ -100,6 +100,7 @@ pub enum HirExpressionKind {
     StringLiteral(String),
     Float(f32),
     Bool(bool),
+    Tuple(Vec<HirExpression>),
     Binary {
         lhs: Box<HirExpression>,
         op: Operator,

--- a/frontend/src/hir/implementation/declarations.rs
+++ b/frontend/src/hir/implementation/declarations.rs
@@ -108,14 +108,14 @@ impl SlynxHir {
         let args = {
             let mut vec = Vec::with_capacity(args.len());
             for arg in args {
-                let (id, _) = self.retrieve_information_of_type(&arg.kind.identifier, &arg.span)?;
+                let id = self.get_typeid_of_generic(&arg.kind)?;
                 vec.push(id);
             }
             vec
         };
         let func_ty = HirType::Function {
             args,
-            return_type: self.get_typeid_of_name(&return_type.identifier, &return_type.span)?,
+            return_type: self.get_typeid_of_generic(return_type)?,
         };
         let symbol = self.symbols_module.intern(&name.identifier);
         let id = self.define_type(symbol, func_ty);

--- a/frontend/src/hir/implementation/expression.rs
+++ b/frontend/src/hir/implementation/expression.rs
@@ -111,6 +111,13 @@ impl SlynxHir {
         ty: Option<TypeId>,
     ) -> Result<HirExpression> {
         match expr.kind {
+            ASTExpressionKind::Tuple(_vector) => {
+                todo!("sla2");
+            }
+            ASTExpressionKind::TupleAccess { .. } => {
+                todo!("sla");
+            }
+
             ASTExpressionKind::If {
                 condition,
                 body,

--- a/frontend/src/hir/implementation/expression.rs
+++ b/frontend/src/hir/implementation/expression.rs
@@ -111,8 +111,24 @@ impl SlynxHir {
         ty: Option<TypeId>,
     ) -> Result<HirExpression> {
         match expr.kind {
-            ASTExpressionKind::Tuple(_vector) => {
-                todo!("sla2");
+            ASTExpressionKind::Tuple(vector) => {
+                let mut types = Vec::new();
+                let mut hir_elements = Vec::new();
+                for element in vector {
+                    let resolved = self.resolve_expr(element, None)?;
+                    types.push(resolved.ty);
+                    hir_elements.push(resolved);
+                }
+                let tuple_ty = self
+                    .types_module
+                    .insert_unnamed_type(HirType::Tuple { fields: types });
+
+                Ok(HirExpression {
+                    id: ExpressionId::new(),
+                    ty: tuple_ty,
+                    kind: HirExpressionKind::Tuple(hir_elements),
+                    span: expr.span,
+                })
             }
             ASTExpressionKind::TupleAccess { .. } => {
                 todo!("sla");

--- a/frontend/src/hir/names.rs
+++ b/frontend/src/hir/names.rs
@@ -7,7 +7,7 @@ use crate::hir::{
     types::HirType,
 };
 
-use common::ast::Span;
+use common::ast::{GenericIdentifier, Span};
 //file specific to implement things related to name resolution
 impl SlynxHir {
     pub fn insert_name(&mut self, name: &str) -> super::symbols::SymbolPointer {
@@ -62,11 +62,13 @@ impl SlynxHir {
     pub fn get_typeid_of_name(&self, name: &str, span: &Span) -> Result<TypeId> {
         match name {
             "Component" => Ok(self.types_module.generic_component_id()),
+            "()" => Ok(self.types_module.void_id()),
             "void" => Ok(self.types_module.void_id()),
             "bool" => Ok(self.types_module.bool_id()),
             "int" => Ok(self.types_module.int_id()),
             "float" => Ok(self.types_module.float_id()),
             "str" => Ok(self.types_module.str_id()),
+
             _ => {
                 let temp = self
                     .symbols_module
@@ -79,6 +81,47 @@ impl SlynxHir {
                     }
                     .into(),
                 )
+            }
+        }
+    }
+
+
+    pub fn get_typeid_of_generic(&mut self, gener: &GenericIdentifier) -> Result<TypeId> {
+        match gener.identifier.as_str() {
+            "tuple" => {
+                if let Some(types) = &gener.generic {
+                    let mut fields = Vec::with_capacity(types.len());
+                    for t in types {
+                        fields.push(self.get_typeid_of_generic(t)?);
+                    }
+                    Ok(self.types_module.add_tuple_type(fields))
+                } else {
+                    Err(HIRError {
+                        kind: HIRErrorKind::NameNotRecognized(gener.identifier.clone()),
+                        span: gener.span.clone(),
+                    }
+                    .into())
+                }
+            }
+            "()" => Ok(self.types_module.void_id()),
+            _ => {
+                if let Some(gens) = &gener.generic {
+                    let gen_ids = {
+                        let mut tmp = Vec::with_capacity(gens.len());
+                        for g in gens {
+                            tmp.push(self.get_typeid_of_generic(g)?);
+                        }
+                        tmp
+                    };
+                    let base_id = self.get_typeid_of_name(&gener.identifier, &gener.span)?;
+                    Ok(self.types_module.insert_unnamed_type(HirType::Reference {
+                        rf: base_id,
+                        generics: gen_ids,
+                    }))
+                } else {
+
+                    self.get_typeid_of_name(&gener.identifier, &gener.span)
+                }
             }
         }
     }

--- a/frontend/src/hir/names.rs
+++ b/frontend/src/hir/names.rs
@@ -85,7 +85,6 @@ impl SlynxHir {
         }
     }
 
-
     pub fn get_typeid_of_generic(&mut self, gener: &GenericIdentifier) -> Result<TypeId> {
         match gener.identifier.as_str() {
             "tuple" => {
@@ -119,7 +118,6 @@ impl SlynxHir {
                         generics: gen_ids,
                     }))
                 } else {
-
                     self.get_typeid_of_name(&gener.identifier, &gener.span)
                 }
             }

--- a/frontend/src/hir/types/mod.rs
+++ b/frontend/src/hir/types/mod.rs
@@ -11,8 +11,8 @@ const VOID_IDX: usize = 3;
 const INFER_IDX: usize = 4;
 const GENERIC_COMPONENT_IDX: usize = 5;
 const BOOL_IDX: usize = 6;
-
-const BUILTIN_TYPES_SIZE: usize = 7;
+const BUILTIN_TYPES_SIZE: usize = 8;
+const TUPLE_IDX: usize = 7;
 
 pub const BUILTIN_TYPES: [HirType; BUILTIN_TYPES_SIZE] = [
     HirType::Int,
@@ -22,6 +22,7 @@ pub const BUILTIN_TYPES: [HirType; BUILTIN_TYPES_SIZE] = [
     HirType::Infer,
     HirType::GenericComponent,
     HirType::Bool,
+    HirType::Tuple { fields: Vec::new() },
 ];
 pub const BUILTIN_NAMES: [&str; BUILTIN_TYPES_SIZE] = [
     "int",
@@ -31,10 +32,12 @@ pub const BUILTIN_NAMES: [&str; BUILTIN_TYPES_SIZE] = [
     "infer",
     "GenericComponent",
     "bool",
+    "tuple",
 ];
 
 #[derive(Debug, Clone)]
 pub struct BuiltinTypes {
+    tuple: TypeId,
     int: TypeId,
 
     float: TypeId,
@@ -67,6 +70,7 @@ impl BuiltinTypes {
             infer: TypeId::from_raw(INFER_IDX as u64),
             generic_component: TypeId::from_raw(GENERIC_COMPONENT_IDX as u64),
             bool: TypeId::from_raw(BOOL_IDX as u64),
+            tuple: TypeId::from_raw(TUPLE_IDX as u64),
         }
     }
 }
@@ -86,7 +90,7 @@ pub struct TypesModule {
 impl TypesModule {
     pub fn new(builtin_names: &[SymbolPointer; BUILTIN_TYPES_SIZE]) -> Self {
         // Keep builtin ids deterministic and fail fast if array order drifts.
-        debug_assert_eq!(BOOL_IDX + 1, BUILTIN_TYPES.len());
+        debug_assert_eq!(BUILTIN_TYPES_SIZE, BUILTIN_TYPES.len());
         debug_assert!(matches!(BUILTIN_TYPES[INT_IDX], HirType::Int));
         debug_assert!(matches!(BUILTIN_TYPES[FLOAT_IDX], HirType::Float));
         debug_assert!(matches!(BUILTIN_TYPES[STR_IDX], HirType::Str));
@@ -111,7 +115,9 @@ impl TypesModule {
         }
         out
     }
-
+    pub fn tuple_id(&self) -> TypeId {
+        self.builtins.tuple
+    }
     pub fn int_id(&self) -> TypeId {
         self.builtins.int
     }

--- a/frontend/src/hir/types/mod.rs
+++ b/frontend/src/hir/types/mod.rs
@@ -11,8 +11,7 @@ const VOID_IDX: usize = 3;
 const INFER_IDX: usize = 4;
 const GENERIC_COMPONENT_IDX: usize = 5;
 const BOOL_IDX: usize = 6;
-const BUILTIN_TYPES_SIZE: usize = 8;
-const TUPLE_IDX: usize = 7;
+const BUILTIN_TYPES_SIZE: usize = 7;
 
 pub const BUILTIN_TYPES: [HirType; BUILTIN_TYPES_SIZE] = [
     HirType::Int,
@@ -22,7 +21,6 @@ pub const BUILTIN_TYPES: [HirType; BUILTIN_TYPES_SIZE] = [
     HirType::Infer,
     HirType::GenericComponent,
     HirType::Bool,
-    HirType::Tuple { fields: Vec::new() },
 ];
 pub const BUILTIN_NAMES: [&str; BUILTIN_TYPES_SIZE] = [
     "int",
@@ -32,12 +30,10 @@ pub const BUILTIN_NAMES: [&str; BUILTIN_TYPES_SIZE] = [
     "infer",
     "GenericComponent",
     "bool",
-    "tuple",
 ];
 
 #[derive(Debug, Clone)]
 pub struct BuiltinTypes {
-    tuple: TypeId,
     int: TypeId,
 
     float: TypeId,
@@ -70,7 +66,6 @@ impl BuiltinTypes {
             infer: TypeId::from_raw(INFER_IDX as u64),
             generic_component: TypeId::from_raw(GENERIC_COMPONENT_IDX as u64),
             bool: TypeId::from_raw(BOOL_IDX as u64),
-            tuple: TypeId::from_raw(TUPLE_IDX as u64),
         }
     }
 }
@@ -115,8 +110,8 @@ impl TypesModule {
         }
         out
     }
-    pub fn tuple_id(&self) -> TypeId {
-        self.builtins.tuple
+    pub fn add_tuple_type(&mut self, fields: Vec<TypeId>) -> TypeId {
+        self.insert_unnamed_type(HirType::Tuple { fields })
     }
     pub fn int_id(&self) -> TypeId {
         self.builtins.int

--- a/frontend/src/hir/types/mod.rs
+++ b/frontend/src/hir/types/mod.rs
@@ -104,8 +104,6 @@ impl TypesModule {
         }
     }
 
-
-
     pub fn add_tuple_type(&mut self, fields: Vec<TypeId>) -> TypeId {
         self.insert_unnamed_type(HirType::Tuple { fields })
     }

--- a/frontend/src/hir/types/mod.rs
+++ b/frontend/src/hir/types/mod.rs
@@ -84,32 +84,28 @@ pub struct TypesModule {
 }
 impl TypesModule {
     pub fn new(builtin_names: &[SymbolPointer; BUILTIN_TYPES_SIZE]) -> Self {
-        // Keep builtin ids deterministic and fail fast if array order drifts.
-        debug_assert_eq!(BUILTIN_TYPES_SIZE, BUILTIN_TYPES.len());
-        debug_assert!(matches!(BUILTIN_TYPES[INT_IDX], HirType::Int));
-        debug_assert!(matches!(BUILTIN_TYPES[FLOAT_IDX], HirType::Float));
-        debug_assert!(matches!(BUILTIN_TYPES[STR_IDX], HirType::Str));
-        debug_assert!(matches!(BUILTIN_TYPES[VOID_IDX], HirType::Void));
-        debug_assert!(matches!(BUILTIN_TYPES[INFER_IDX], HirType::Infer));
-        debug_assert!(matches!(
-            BUILTIN_TYPES[GENERIC_COMPONENT_IDX],
-            HirType::GenericComponent
-        ));
-        debug_assert!(matches!(BUILTIN_TYPES[BOOL_IDX], HirType::Bool));
-
-        let builtins = BuiltinTypes::new();
-        let mut out = Self {
-            name_of_types: HashMap::new(),
-            types: Vec::new(),
-            builtins,
-            type_names: HashMap::new(),
-            variables: HashMap::new(),
-        };
-        for (idx, name) in builtin_names.iter().enumerate() {
-            out.insert_type(*name, BUILTIN_TYPES[idx].clone());
+        let mut types = Vec::with_capacity(BUILTIN_TYPES_SIZE);
+        let mut type_names = HashMap::new();
+        let mut name_of_types = HashMap::new();
+        for ty in BUILTIN_TYPES.iter() {
+            types.push(ty.clone());
         }
-        out
+        for (idx, name_symbol) in builtin_names.iter().enumerate() {
+            let id = TypeId::from_raw(idx as u64);
+            type_names.insert(*name_symbol, id);
+            name_of_types.insert(id, *name_symbol);
+        }
+        Self {
+            type_names,
+            name_of_types,
+            variables: HashMap::new(),
+            types,
+            builtins: BuiltinTypes::new(),
+        }
     }
+
+
+
     pub fn add_tuple_type(&mut self, fields: Vec<TypeId>) -> TypeId {
         self.insert_unnamed_type(HirType::Tuple { fields })
     }

--- a/frontend/src/hir/types/tys.rs
+++ b/frontend/src/hir/types/tys.rs
@@ -33,6 +33,9 @@ pub enum HirType {
     Vector {
         ty: TypeId,
     },
+    Tuple {
+        fields: Vec<TypeId>,
+    },
     ///This reference type can be understood better explained like
     ///object Name<T> {
     ///  value: T

--- a/frontend/src/lexer/tokens.rs
+++ b/frontend/src/lexer/tokens.rs
@@ -1,6 +1,6 @@
 use common::ast::Span;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Token {
     pub kind: TokenKind,
     pub span: Span,
@@ -64,7 +64,7 @@ impl std::fmt::Display for TokenKind {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TokenKind {
     While,
     CommonComent,

--- a/frontend/src/parser/expr.rs
+++ b/frontend/src/parser/expr.rs
@@ -132,14 +132,13 @@ impl Parser {
         })
     }
     ///Parses a tuple expression, which follows the rule (expr, expr, expr) or ()
-    pub fn parse_tuple(&mut self) -> Result<ASTExpression> {
-        let start = self.expect(&TokenKind::LParen)?;
+    pub fn parse_tuple(&mut self, start_span: &Span) -> Result<ASTExpression> {
         if self.peek()?.kind == TokenKind::RParen {
             let end = self.eat()?;
             return Ok(ASTExpression {
                 kind: ASTExpressionKind::Tuple(vec![]),
                 span: Span {
-                    start: start.span.start,
+                    start: start_span.start,
                     end: end.span.end,
                 },
             });
@@ -152,19 +151,17 @@ impl Parser {
         }
         self.expect(&TokenKind::Comma)?;
         let mut itens = vec![first];
-
         while self.peek()?.kind != TokenKind::RParen {
             itens.push(self.parse_expression()?);
             if self.peek()?.kind == TokenKind::Comma {
                 self.eat()?;
             }
         }
-
         let end = self.expect(&TokenKind::RParen)?;
         Ok(ASTExpression {
             kind: ASTExpressionKind::Tuple(itens),
             span: Span {
-                start: start.span.start,
+                start: start_span.start,
                 end: end.span.end,
             },
         })
@@ -269,7 +266,7 @@ impl Parser {
                     span: current.span,
                 }),
                 TokenKind::LParen => {
-                    let expr = self.parse_tuple()?;
+                    let expr = self.parse_tuple(&current.span)?;
                     Ok(expr)
                 }
 

--- a/frontend/src/parser/expr.rs
+++ b/frontend/src/parser/expr.rs
@@ -131,7 +131,31 @@ impl Parser {
             expr,
         })
     }
-
+    pub fn parse_tuple(&mut self) -> Result<ASTExpression> {
+        let start = self.expect(&TokenKind::LParen)?;
+        let mut itens = Vec::new();
+        let mut encontrei = false;
+        while self.peek()?.kind != TokenKind::RParen {
+            let value = self.parse_expression()?;
+            itens.push(value);
+            if self.peek()?.kind == TokenKind::Comma {
+                encontrei = true;
+                self.eat()?;
+            }
+        }
+        let end = self.expect(&TokenKind::RParen)?;
+        if !encontrei && itens.len() == 1 {
+            Ok(itens.remove(0))
+        } else {
+            Ok(ASTExpression {
+                kind: ASTExpressionKind::Tuple(itens),
+                span: Span {
+                    start: start.span.start,
+                    end: end.span.end,
+                },
+            })
+        }
+    }
     ///Parses an object expression, which follows the rule Object(field: expr, field: value)
     pub fn parse_object_expression(&mut self) -> Result<ASTExpression> {
         let name = self.parse_type()?;
@@ -232,8 +256,7 @@ impl Parser {
                     span: current.span,
                 }),
                 TokenKind::LParen => {
-                    let expr = self.parse_expression()?;
-                    self.expect(&TokenKind::RParen)?;
+                    let expr = self.parse_tuple()?;
                     Ok(expr)
                 }
 

--- a/frontend/src/parser/expr.rs
+++ b/frontend/src/parser/expr.rs
@@ -131,30 +131,43 @@ impl Parser {
             expr,
         })
     }
+    ///Parses a tuple expression, which follows the rule (expr, expr, expr) or ()
     pub fn parse_tuple(&mut self) -> Result<ASTExpression> {
         let start = self.expect(&TokenKind::LParen)?;
-        let mut itens = Vec::new();
-        let mut encontrei = false;
-        while self.peek()?.kind != TokenKind::RParen {
-            let value = self.parse_expression()?;
-            itens.push(value);
-            if self.peek()?.kind == TokenKind::Comma {
-                encontrei = true;
-                self.eat()?;
-            }
-        }
-        let end = self.expect(&TokenKind::RParen)?;
-        if !encontrei && itens.len() == 1 {
-            Ok(itens.remove(0))
-        } else {
-            Ok(ASTExpression {
-                kind: ASTExpressionKind::Tuple(itens),
+        if self.peek()?.kind == TokenKind::RParen {
+            let end = self.eat()?;
+            return Ok(ASTExpression {
+                kind: ASTExpressionKind::Tuple(vec![]),
                 span: Span {
                     start: start.span.start,
                     end: end.span.end,
                 },
-            })
+            });
         }
+
+        let first = self.parse_expression()?;
+        if self.peek()?.kind == TokenKind::RParen {
+            let _ = self.eat()?;
+            return Ok(first);
+        }
+        self.expect(&TokenKind::Comma)?;
+        let mut itens = vec![first];
+
+        while self.peek()?.kind != TokenKind::RParen {
+            itens.push(self.parse_expression()?);
+            if self.peek()?.kind == TokenKind::Comma {
+                self.eat()?;
+            }
+        }
+
+        let end = self.expect(&TokenKind::RParen)?;
+        Ok(ASTExpression {
+            kind: ASTExpressionKind::Tuple(itens),
+            span: Span {
+                start: start.span.start,
+                end: end.span.end,
+            },
+        })
     }
     ///Parses an object expression, which follows the rule Object(field: expr, field: value)
     pub fn parse_object_expression(&mut self) -> Result<ASTExpression> {

--- a/frontend/src/parser/types.rs
+++ b/frontend/src/parser/types.rs
@@ -93,8 +93,6 @@ impl Parser {
                 },
             });
         }
-
-        // resto original inalterado
         let Token {
             kind: TokenKind::Identifier(ident),
             mut span,

--- a/frontend/src/parser/types.rs
+++ b/frontend/src/parser/types.rs
@@ -1,5 +1,8 @@
 use super::Parser;
-use crate::lexer::tokens::{Token, TokenKind};
+use crate::{
+    lexer::tokens::{Token, TokenKind},
+    parser::error::ParseError,
+};
 use color_eyre::eyre::Result;
 use common::{ASTDeclaration, ASTDeclarationKind, Span, ast::GenericIdentifier};
 impl Parser {
@@ -47,6 +50,51 @@ impl Parser {
 
     ///Parses a type.
     pub fn parse_type(&mut self) -> Result<GenericIdentifier> {
+        let token = self.peek()?;
+        let start_span = token.span.clone();
+
+        if let TokenKind::LParen = &token.kind {
+            self.eat()?;
+            if let TokenKind::RParen = self.peek()?.kind {
+                let end_span = self.eat()?.span;
+                return Ok(GenericIdentifier {
+                    identifier: "()".to_string(),
+                    generic: None,
+                    span: Span {
+                        start: start_span.start,
+                        end: end_span.end,
+                    },
+                });
+            }
+            let mut types = Vec::new();
+            loop {
+                types.push(self.parse_type()?);
+                match self.peek()?.kind {
+                    TokenKind::Comma => {
+                        self.eat()?;
+                    }
+                    TokenKind::RParen => break,
+                    _ => {
+                        return Err(ParseError::UnexpectedToken(
+                            self.eat()?,
+                            "expected ',' or ')' in tuple type".into(),
+                        )
+                        .into());
+                    }
+                }
+            }
+            let end_span = self.eat()?.span;
+            return Ok(GenericIdentifier {
+                identifier: "tuple".to_string(),
+                generic: Some(types),
+                span: Span {
+                    start: start_span.start,
+                    end: end_span.end,
+                },
+            });
+        }
+
+        // resto original inalterado
         let Token {
             kind: TokenKind::Identifier(ident),
             mut span,

--- a/frontend/tests/hir.rs
+++ b/frontend/tests/hir.rs
@@ -1,0 +1,31 @@
+use common::{ASTExpression, ASTExpressionKind, Span};
+use frontend::hir::{SlynxHir, types::HirType};
+
+fn generate_hir(kind: ASTExpressionKind) -> ASTExpression {
+    let span = Span { start: 0, end: 0 };
+    ASTExpression { kind, span }
+}
+
+#[test]
+fn test_hir_tuple() {
+    let tuple_ast = generate_hir(ASTExpressionKind::Tuple(vec![
+        generate_hir(ASTExpressionKind::FloatLiteral(1.9)),
+        generate_hir(ASTExpressionKind::IntLiteral(42)),
+    ]));
+    let mut hir = SlynxHir::new();
+    let result = hir.resolve_expr(tuple_ast, None);
+    assert!(result.is_ok(), "err in tuple hir: {:?}", result);
+    let tuple_hir = result.unwrap();
+    match tuple_hir.kind {
+        frontend::hir::definitions::HirExpressionKind::Tuple(ref elements) => {
+            assert_eq!(elements.len(), 2);
+        }
+        _ => panic!("expected HirExpressionKind::Tuple"),
+    }
+    match hir.types_module.get_type(&tuple_hir.ty) {
+        HirType::Tuple { fields } => {
+            assert_eq!(fields.len(), 2);
+        }
+        _ => panic!("expected HirType::Tuple"),
+    }
+}

--- a/frontend/tests/parser.rs
+++ b/frontend/tests/parser.rs
@@ -30,7 +30,27 @@ fn function_body<'a>(declarations: &'a [ASTDeclaration], name: &str) -> &'a [AST
 
     body.as_slice()
 }
+#[test]
+fn parses_function_body_tuple() {
+    let declarations = parse_source(
+        r#"
+func main(): int {
+    let value = (1, (1,2,3));
+    value
+}
+"#,
+    );
 
+    let body = function_body(&declarations, "main");
+    assert_eq!(body.len(), 2);
+
+    let ASTStatementKind::Var { name, ty, rhs } = &body[0].kind else {
+        panic!("expected let statement");
+    };
+    assert_eq!(name, "value");
+    assert!(ty.is_none());
+    assert!(matches!(rhs.kind, ASTExpressionKind::Tuple(_)));
+}
 #[test]
 fn parses_function_body_statement_shapes() {
     let declarations = parse_source(

--- a/frontend/tests/types.rs
+++ b/frontend/tests/types.rs
@@ -1,0 +1,79 @@
+use frontend::hir::{SlynxHir, types::HirType};
+
+#[test]
+fn test_create_tuple_type() {
+    let mut hir = SlynxHir::new();
+    let int_id = hir.types_module.int_id();
+    let float_id = hir.types_module.float_id();
+
+    let tuple_id = hir
+        .types_module
+        .insert_unnamed_type(HirType::Tuple { fields: vec![int_id, float_id] });
+
+    match hir.types_module.get_type(&tuple_id) {
+        HirType::Tuple { fields } => {
+            assert_eq!(fields.len(), 2);
+            assert_eq!(fields[0], int_id);
+            assert_eq!(fields[1], float_id);
+        }
+        other => panic!("expected HirType::Tuple, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_create_empty_tuple_type() {
+    let mut hir = SlynxHir::new();
+
+    let tuple_id = hir
+        .types_module
+        .insert_unnamed_type(HirType::Tuple { fields: vec![] });
+
+    match hir.types_module.get_type(&tuple_id) {
+        HirType::Tuple { fields } => {
+            assert_eq!(fields.len(), 0);
+        }
+        other => panic!("expected HirType::Tuple, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_tuple_fields_are_independent_type_ids() {
+    let mut hir = SlynxHir::new();
+    let int_id = hir.types_module.int_id();
+    let str_id = hir.types_module.str_id();
+    let bool_id = hir.types_module.bool_id();
+
+    let tuple_id = hir
+        .types_module
+        .insert_unnamed_type(HirType::Tuple { fields: vec![int_id, str_id, bool_id] });
+
+    match hir.types_module.get_type(&tuple_id) {
+        HirType::Tuple { fields } => {
+            assert_eq!(fields.len(), 3);
+            assert_eq!(fields[0], int_id);
+            assert_eq!(fields[1], str_id);
+            assert_eq!(fields[2], bool_id);
+            assert_ne!(fields[0], fields[1]);
+            assert_ne!(fields[1], fields[2]);
+            assert_ne!(fields[0], fields[2]);
+        }
+        other => panic!("expected HirType::Tuple, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_two_tuple_types_are_independent() {
+    let mut hir = SlynxHir::new();
+    let int_id = hir.types_module.int_id();
+    let float_id = hir.types_module.float_id();
+
+    let tuple_a = hir
+        .types_module
+        .insert_unnamed_type(HirType::Tuple { fields: vec![int_id] });
+
+    let tuple_b = hir
+        .types_module
+        .insert_unnamed_type(HirType::Tuple { fields: vec![float_id] });
+
+    assert_ne!(tuple_a, tuple_b, "two separately inserted tuples should have distinct IDs");
+}

--- a/frontend/tests/types.rs
+++ b/frontend/tests/types.rs
@@ -6,9 +6,9 @@ fn test_create_tuple_type() {
     let int_id = hir.types_module.int_id();
     let float_id = hir.types_module.float_id();
 
-    let tuple_id = hir
-        .types_module
-        .insert_unnamed_type(HirType::Tuple { fields: vec![int_id, float_id] });
+    let tuple_id = hir.types_module.insert_unnamed_type(HirType::Tuple {
+        fields: vec![int_id, float_id],
+    });
 
     match hir.types_module.get_type(&tuple_id) {
         HirType::Tuple { fields } => {
@@ -43,9 +43,9 @@ fn test_tuple_fields_are_independent_type_ids() {
     let str_id = hir.types_module.str_id();
     let bool_id = hir.types_module.bool_id();
 
-    let tuple_id = hir
-        .types_module
-        .insert_unnamed_type(HirType::Tuple { fields: vec![int_id, str_id, bool_id] });
+    let tuple_id = hir.types_module.insert_unnamed_type(HirType::Tuple {
+        fields: vec![int_id, str_id, bool_id],
+    });
 
     match hir.types_module.get_type(&tuple_id) {
         HirType::Tuple { fields } => {
@@ -67,13 +67,16 @@ fn test_two_tuple_types_are_independent() {
     let int_id = hir.types_module.int_id();
     let float_id = hir.types_module.float_id();
 
-    let tuple_a = hir
-        .types_module
-        .insert_unnamed_type(HirType::Tuple { fields: vec![int_id] });
+    let tuple_a = hir.types_module.insert_unnamed_type(HirType::Tuple {
+        fields: vec![int_id],
+    });
 
-    let tuple_b = hir
-        .types_module
-        .insert_unnamed_type(HirType::Tuple { fields: vec![float_id] });
+    let tuple_b = hir.types_module.insert_unnamed_type(HirType::Tuple {
+        fields: vec![float_id],
+    });
 
-    assert_ne!(tuple_a, tuple_b, "two separately inserted tuples should have distinct IDs");
+    assert_ne!(
+        tuple_a, tuple_b,
+        "two separately inserted tuples should have distinct IDs"
+    );
 }

--- a/middleend/src/ir/contexts.rs
+++ b/middleend/src/ir/contexts.rs
@@ -67,6 +67,9 @@ impl SlynxIR {
         temp: &mut TempIRData,
     ) -> Result<IRPointer<Value, 1>, IRError> {
         let value = match &expr.kind {
+            HirExpressionKind::Tuple(_) => {
+                todo!()
+            }
             HirExpressionKind::StringLiteral(v) => {
                 let handle_idx = self.strings.intern(v);
                 let operand = Operand::String(handle_idx);

--- a/middleend/src/ir/contexts.rs
+++ b/middleend/src/ir/contexts.rs
@@ -73,10 +73,10 @@ impl SlynxIR {
                     .map(|e| self.get_value_for(e, temp))
                     .collect::<Result<Vec<_>, _>>()?;
                 let mut element_types = Vec::with_capacity(values_ptrs.len());
-                    for ptr in &values_ptrs {
-                        let ty = self.get_type_of_value(ptr.clone(), temp);
-                        element_types.push(ty);
-                    }
+                for ptr in &values_ptrs {
+                    let ty = self.get_type_of_value(ptr.clone(), temp);
+                    element_types.push(ty);
+                }
                 let values = values_ptrs
                     .iter()
                     .map(|v| self.get_value(v.clone()))

--- a/middleend/src/ir/contexts.rs
+++ b/middleend/src/ir/contexts.rs
@@ -83,7 +83,7 @@ impl SlynxIR {
                     .collect::<Vec<_>>();
                 let values_ptr = self.insert_values(&values);
 
-                let ty = self.types.create_tuple(element_types);
+                let ty = self.types.create_or_get_tuple(element_types);
                 Value::StructLiteral(ty, values_ptr)
             }
             HirExpressionKind::StringLiteral(v) => {

--- a/middleend/src/ir/contexts.rs
+++ b/middleend/src/ir/contexts.rs
@@ -67,8 +67,24 @@ impl SlynxIR {
         temp: &mut TempIRData,
     ) -> Result<IRPointer<Value, 1>, IRError> {
         let value = match &expr.kind {
-            HirExpressionKind::Tuple(_) => {
-                todo!()
+            HirExpressionKind::Tuple(vetor) => {
+                let values_ptrs = vetor
+                    .iter()
+                    .map(|e| self.get_value_for(e, temp))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let mut element_types = Vec::with_capacity(values_ptrs.len());
+                    for ptr in &values_ptrs {
+                        let ty = self.get_type_of_value(ptr.clone(), temp);
+                        element_types.push(ty);
+                    }
+                let values = values_ptrs
+                    .iter()
+                    .map(|v| self.get_value(v.clone()))
+                    .collect::<Vec<_>>();
+                let values_ptr = self.insert_values(&values);
+
+                let ty = self.types.create_tuple(element_types);
+                Value::StructLiteral(ty, values_ptr)
             }
             HirExpressionKind::StringLiteral(v) => {
                 let handle_idx = self.strings.intern(v);

--- a/middleend/src/ir/helper/types.rs
+++ b/middleend/src/ir/helper/types.rs
@@ -15,7 +15,7 @@ impl SlynxIR {
     #[inline]
     ///Gets the type of the ir based on the provided `hirty`. Uses `temp` and `tymod` as auxiliary
     pub fn get_ir_type(
-        &self,
+        &mut self,
         hirty: &TypeId,
         temp: &TempIRData,
         tymod: &TypesModule,
@@ -27,7 +27,22 @@ impl SlynxIR {
             ty if ty == tymod.void_id() => self.types.void_type(),
             ty if ty == tymod.str_id() => self.types.str_type(),
             ty if ty == tymod.generic_component_id() => self.types.generic_component_type(),
-            ty => temp.get_type(ty)?,
+            ty => {
+                if let Ok(mapped) = temp.get_type(ty) {
+                    return Ok(mapped);
+                }
+                match tymod.get_type(&ty) {
+                    HirType::Tuple { fields } => {
+                        let fields = fields.clone();
+                        let ir_fields = fields
+                            .iter()
+                            .map(|f| self.get_ir_type(f, temp, tymod))
+                            .collect::<Result<Vec<_>, _>>()?;
+                        self.types.create_or_get_tuple(ir_fields)
+                    }
+                    _ => return Err(IRError::IRTypeNotRecognized(ty)),
+                }
+            }
         })
     }
 

--- a/middleend/src/types/irtype.rs
+++ b/middleend/src/types/irtype.rs
@@ -1,4 +1,4 @@
-use crate::{IRComponentId, IRStructId, types::functions::IRFunctionId};
+use crate::{IRComponentId, IRStructId, IRTupleId, types::functions::IRFunctionId};
 
 /// Logical identifier for a type inside IR type storage.
 ///
@@ -20,6 +20,7 @@ pub enum IRType {
     BOOL,
     VOID,
     GenericComponent,
+    Tuple(IRTupleId),
     Component(IRComponentId),
     Struct(IRStructId),
     Function(IRFunctionId),

--- a/middleend/src/types/mod.rs
+++ b/middleend/src/types/mod.rs
@@ -2,10 +2,12 @@ mod components;
 mod functions;
 mod irtype;
 mod structs;
+mod tuple;
 pub use components::*;
 pub use functions::*;
 pub use irtype::*;
 pub use structs::*;
+pub use tuple::*;
 
 pub const BUILTIN_TYPES: &[IRType] = &[
     IRType::I8,
@@ -29,6 +31,7 @@ pub const BUILTIN_TYPES: &[IRType] = &[
 #[derive(Debug, Default)]
 pub struct IRTypes {
     types: Vec<IRType>,
+    tuples: Vec<IRTuple>,
     structs: Vec<IRStruct>,
     functions: Vec<IRFunction>,
     components: Vec<IRComponent>,
@@ -41,6 +44,7 @@ impl IRTypes {
             structs: Vec::new(),
             functions: Vec::new(),
             components: Vec::new(),
+            tuples: Vec::new(),
         }
     }
 
@@ -167,4 +171,13 @@ impl IRTypes {
         self.types.push(IRType::Function(IRFunctionId(fout)));
         IRTypeId(out)
     }
+    ///Creates a new tuple type with the given elements and returns its type ID.
+    pub fn create_tuple(&mut self, elements: Vec<IRTypeId>) -> IRTypeId {
+        let tout = self.tuples.len();
+        self.tuples.push(IRTuple { elements });
+        let out = self.types.len();
+        self.types.push(IRType::Tuple(IRTupleId(tout)));
+        IRTypeId(out)
+    }
+
 }

--- a/middleend/src/types/mod.rs
+++ b/middleend/src/types/mod.rs
@@ -179,5 +179,4 @@ impl IRTypes {
         self.types.push(IRType::Tuple(IRTupleId(tout)));
         IRTypeId(out)
     }
-
 }

--- a/middleend/src/types/mod.rs
+++ b/middleend/src/types/mod.rs
@@ -31,7 +31,7 @@ pub const BUILTIN_TYPES: &[IRType] = &[
 #[derive(Debug, Default)]
 pub struct IRTypes {
     types: Vec<IRType>,
-    tuples: Vec<IRTuple>,
+
     structs: Vec<IRStruct>,
     functions: Vec<IRFunction>,
     components: Vec<IRComponent>,
@@ -44,7 +44,6 @@ impl IRTypes {
             structs: Vec::new(),
             functions: Vec::new(),
             components: Vec::new(),
-            tuples: Vec::new(),
         }
     }
 
@@ -171,12 +170,25 @@ impl IRTypes {
         self.types.push(IRType::Function(IRFunctionId(fout)));
         IRTypeId(out)
     }
-    ///Creates a new tuple type with the given elements and returns its type ID.
-    pub fn create_tuple(&mut self, elements: Vec<IRTypeId>) -> IRTypeId {
-        let tout = self.tuples.len();
-        self.tuples.push(IRTuple { elements });
-        let out = self.types.len();
-        self.types.push(IRType::Tuple(IRTupleId(tout)));
-        IRTypeId(out)
+    pub fn create_or_get_tuple(&mut self, elements: Vec<IRTypeId>) -> IRTypeId {
+        for (i, strukt) in self.structs.iter().enumerate() {
+            if strukt.get_fields() == elements {
+                return IRTypeId(
+                    self.types
+                        .iter()
+                        .position(|t| matches!(t, IRType::Struct(id) if id.0 == i))
+                        .unwrap(),
+                );
+            }
+        }
+        let mut s = IRStruct::new();
+        for field in elements {
+            s.insert_field(field);
+        }
+        let sid = IRStructId(self.structs.len());
+        self.structs.push(s);
+        let tid = IRTypeId(self.types.len());
+        self.types.push(IRType::Struct(sid));
+        tid
     }
 }

--- a/middleend/src/types/tuple.rs
+++ b/middleend/src/types/tuple.rs
@@ -1,0 +1,63 @@
+use crate::IRTypeId;
+
+/// Represents a tuple type in the Intermediate Representation (IR).
+///
+/// An `IRTuple` is a **composite type** made of an ordered list of element types.
+/// Each element is identified by an [`IRTypeId`], allowing the tuple to reference
+/// types stored in the central IR type table.
+/// This struct represents the **data** of a tuple,
+/// while [`IRTupleId`] is used as a lightweight handle (index)
+/// into the tuple storage inside `IRTypes`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IRTuple {
+    /// Ordered list of element types that make up the tuple.
+    pub elements: Vec<IRTypeId>,
+}
+
+/// A compact identifier for a tuple type stored in the IR.
+///
+/// This is essentially an index into the `IRTypes.tuples` storage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct IRTupleId(pub usize);
+
+impl IRTuple {
+    /// Creates a new tuple type from a list of element types.
+    ///
+    /// # Arguments
+    ///
+    /// * `elements` - A vector of [`IRTypeId`] representing the types of each element.
+    pub fn new(elements: Vec<IRTypeId>) -> Self {
+        Self { elements }
+    }
+
+    /// Returns a slice of all element types in the tuple.
+    /// This is useful for iteration or inspection without cloning.
+    pub fn types(&self) -> &[IRTypeId] {
+        &self.elements
+    }
+
+    /// Returns `true` if the tuple has no elements.
+     pub fn is_empty(&self) -> bool {
+        self.elements.is_empty()
+    }
+
+    /// Returns the number of elements in the tuple.
+
+    pub fn len(&self) -> usize {
+        self.elements.len()
+    }
+
+    /// Returns the type of the element at the given index, if it exists.
+    ///
+    /// # Arguments
+    ///
+    /// * `index` - The position of the element in the tuple.
+    ///
+    /// # Returns
+    ///
+    /// - `Some(&IRTypeId)` if the index is valid
+    /// - `None` if the index is out of bounds
+    pub fn get(&self, index: usize) -> Option<&IRTypeId> {
+        self.elements.get(index)
+    }
+}

--- a/middleend/src/types/tuple.rs
+++ b/middleend/src/types/tuple.rs
@@ -37,12 +37,11 @@ impl IRTuple {
     }
 
     /// Returns `true` if the tuple has no elements.
-     pub fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.elements.is_empty()
     }
 
     /// Returns the number of elements in the tuple.
-
     pub fn len(&self) -> usize {
         self.elements.len()
     }

--- a/slynx/tuplas.sir
+++ b/slynx/tuplas.sir
@@ -1,0 +1,276 @@
+SlynxIR {
+    contexts: [
+        Context {
+            labels: IRPointer {
+                inner: 1,
+                data: PhantomData<middleend::ir::model::label::Label>,
+            },
+            ty: IRTypeId(
+                16,
+            ),
+        },
+    ],
+    components: [],
+    labels: [
+        Label {
+            instruction: IRPointer {
+                inner: 4,
+                data: PhantomData<middleend::ir::model::instruction::Instruction>,
+            },
+            arguments: [],
+        },
+    ],
+    instructions: [
+        Instruction {
+            operands: IRPointer {
+                inner: 1,
+                data: PhantomData<middleend::ir::model::instruction::Value>,
+            },
+            instruction_type: RawValue,
+            value_type: IRTypeId(
+                4,
+            ),
+        },
+        Instruction {
+            operands: IRPointer {
+                inner: 131073,
+                data: PhantomData<middleend::ir::model::instruction::Value>,
+            },
+            instruction_type: RawValue,
+            value_type: IRTypeId(
+                4,
+            ),
+        },
+        Instruction {
+            operands: IRPointer {
+                inner: 458753,
+                data: PhantomData<middleend::ir::model::instruction::Value>,
+            },
+            instruction_type: RawValue,
+            value_type: IRTypeId(
+                4,
+            ),
+        },
+        Instruction {
+            operands: IRPointer {
+                inner: 720897,
+                data: PhantomData<middleend::ir::model::instruction::Value>,
+            },
+            instruction_type: Ret,
+            value_type: IRTypeId(
+                18,
+            ),
+        },
+    ],
+    operands: [
+        Int(
+            1,
+        ),
+        Int(
+            1,
+        ),
+        Int(
+            1,
+        ),
+    ],
+    values: [
+        Raw(
+            IRPointer {
+                inner: 1,
+                data: PhantomData<middleend::ir::model::instruction::Operand>,
+            },
+        ),
+        Instruction(
+            IRPointer {
+                inner: 1,
+                data: PhantomData<middleend::ir::model::instruction::Instruction>,
+            },
+        ),
+        Raw(
+            IRPointer {
+                inner: 65537,
+                data: PhantomData<middleend::ir::model::instruction::Operand>,
+            },
+        ),
+        Instruction(
+            IRPointer {
+                inner: 65538,
+                data: PhantomData<middleend::ir::model::instruction::Instruction>,
+            },
+        ),
+        Instruction(
+            IRPointer {
+                inner: 1,
+                data: PhantomData<middleend::ir::model::instruction::Instruction>,
+            },
+        ),
+        Instruction(
+            IRPointer {
+                inner: 65538,
+                data: PhantomData<middleend::ir::model::instruction::Instruction>,
+            },
+        ),
+        StructLiteral(
+            IRTypeId(
+                17,
+            ),
+            IRPointer {
+                inner: 262146,
+                data: PhantomData<middleend::ir::model::instruction::Value>,
+            },
+        ),
+        Raw(
+            IRPointer {
+                inner: 131073,
+                data: PhantomData<middleend::ir::model::instruction::Operand>,
+            },
+        ),
+        Instruction(
+            IRPointer {
+                inner: 131075,
+                data: PhantomData<middleend::ir::model::instruction::Instruction>,
+            },
+        ),
+        StructLiteral(
+            IRTypeId(
+                17,
+            ),
+            IRPointer {
+                inner: 262146,
+                data: PhantomData<middleend::ir::model::instruction::Value>,
+            },
+        ),
+        Instruction(
+            IRPointer {
+                inner: 131075,
+                data: PhantomData<middleend::ir::model::instruction::Instruction>,
+            },
+        ),
+        StructLiteral(
+            IRTypeId(
+                18,
+            ),
+            IRPointer {
+                inner: 589826,
+                data: PhantomData<middleend::ir::model::instruction::Value>,
+            },
+        ),
+    ],
+    slots: [],
+    types: IRTypes {
+        types: [
+            I8,
+            U8,
+            I16,
+            U16,
+            I32,
+            U32,
+            I64,
+            U64,
+            ISIZE,
+            USIZE,
+            F32,
+            F64,
+            STR,
+            BOOL,
+            VOID,
+            GenericComponent,
+            Function(
+                IRFunctionId(
+                    0,
+                ),
+            ),
+            Struct(
+                IRStructId(
+                    0,
+                ),
+            ),
+            Struct(
+                IRStructId(
+                    1,
+                ),
+            ),
+        ],
+        structs: [
+            IRStruct {
+                fields: [
+                    IRTypeId(
+                        4,
+                    ),
+                    IRTypeId(
+                        4,
+                    ),
+                ],
+            },
+            IRStruct {
+                fields: [
+                    IRTypeId(
+                        17,
+                    ),
+                    IRTypeId(
+                        4,
+                    ),
+                ],
+            },
+        ],
+        functions: [
+            IRFunction {
+                args: [],
+                ret: IRTypeId(
+                    18,
+                ),
+            },
+        ],
+        components: [],
+    },
+    strings: SymbolsModule {
+        names: InternalizedString {
+            inner: [
+                105,
+                110,
+                116,
+                102,
+                108,
+                111,
+                97,
+                116,
+                115,
+                116,
+                114,
+                118,
+                111,
+                105,
+                100,
+                105,
+                110,
+                102,
+                101,
+                114,
+                71,
+                101,
+                110,
+                101,
+                114,
+                105,
+                99,
+                67,
+                111,
+                109,
+                112,
+                111,
+                110,
+                101,
+                110,
+                116,
+                98,
+                111,
+                111,
+                108,
+                109,
+                97,
+                105,
+                110,
+            ],
+        },
+    }Ok(()),
+}

--- a/slynx/tuplas.sly
+++ b/slynx/tuplas.sly
@@ -1,3 +1,4 @@
+
 func main (): ((int, int), int){
     ((1,1), 1)
 }

--- a/slynx/tuplas.sly
+++ b/slynx/tuplas.sly
@@ -1,0 +1,3 @@
+func main (): ((int, int), int){
+    ((1,1), 1)
+}


### PR DESCRIPTION
## Summary

This pull request adds the tuple type (without access between others).

## Scope

- now we can remove things with tuples ```("or", "ei")```
- tuple literal type
 
## Validation

List the commands, tests, or manual checks you ran.

```bash
# example
cargo test
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
```

## Documentation Impact

- [ ] No documentation changes were needed
- [X] I updated the relevant documentation

## Checklist

- [ ] My change is focused and reviewable
- [X] I performed a self-review
- [X] I added comments only where they help explain non-obvious logic
- [X] I added or updated tests when applicable
- [X] I ran the validation listed above
- [X] I used the existing issue/PR templates where applicable

## Related Issues

progress #(99)
