### PR TITLE
Fix: stabilize alias field access and monomorphization

### DIFF
--- a/frontend/src/checker/expr.rs
+++ b/frontend/src/checker/expr.rs
@@ -42,7 +42,6 @@ impl TypeChecker {
                 *field_ty = self
                     .types_module
                     .insert_unnamed_type(HirType::Field(FieldMethod::Type(rf, index)));
-                println!("{field_ty:?}");
                 self.resolve(field_ty, span)
             }
             FieldMethod::Variable(variable_id, field_name) => {
@@ -56,16 +55,11 @@ impl TypeChecker {
                         kind: TypeErrorKind::Unrecognized,
                         span: span.clone(),
                     })?;
-
-                let HirType::Reference { rf, .. } =
-                    self.retrieve_reference_of(&variable_id, span)?
-                else {
-                    unreachable!();
-                };
+                let layout_ty = self.get_object_layout_type(&object_ty, span)?;
 
                 let Some(index) = self
                     .structs
-                    .get(&object_ty)
+                    .get(&layout_ty)
                     .expect("Type should be defined")
                     .iter()
                     .position(|field| *field == field_name)
@@ -79,7 +73,7 @@ impl TypeChecker {
 
                 *field_index = index;
                 *self.types_module.get_type_mut(field_ty) =
-                    HirType::Field(FieldMethod::Type(rf, index));
+                    HirType::Field(FieldMethod::Type(object_ty, index));
                 self.resolve(field_ty, span)
             }
         }

--- a/frontend/src/checker/mod.rs
+++ b/frontend/src/checker/mod.rs
@@ -9,7 +9,7 @@ use color_eyre::eyre::Result;
 use crate::checker::error::{IncompatibleComponentReason, TypeError, TypeErrorKind};
 
 use crate::hir::{
-    SlynxHir, TypeId, VariableId,
+    SlynxHir, TypeId,
     definitions::{HirDeclaration, HirDeclarationKind},
     symbols::SymbolPointer,
     types::{FieldMethod, HirType, TypesModule},
@@ -31,6 +31,43 @@ pub struct TypeChecker {
 }
 
 impl TypeChecker {
+    fn get_object_layout_type(&self, ty: &TypeId, span: &Span) -> Result<TypeId> {
+        let mut current = *ty;
+
+        loop {
+            match self.types_module.get_type(&current) {
+                HirType::Reference { rf, .. } => match self.types_module.get_type(rf) {
+                    HirType::Struct { .. } => return Ok(current),
+                    HirType::Reference { .. } => current = *rf,
+                    other => {
+                        return Err(TypeError {
+                            kind: TypeErrorKind::NotAStruct(other.clone()),
+                            span: span.clone(),
+                        }
+                        .into());
+                    }
+                },
+                HirType::VarReference(variable_id) => {
+                    current =
+                        self.types_module
+                            .get_variable(variable_id)
+                            .copied()
+                            .ok_or(TypeError {
+                                kind: TypeErrorKind::Unrecognized,
+                                span: span.clone(),
+                            })?;
+                }
+                other => {
+                    return Err(TypeError {
+                        kind: TypeErrorKind::NotAStruct(other.clone()),
+                        span: span.clone(),
+                    }
+                    .into());
+                }
+            }
+        }
+    }
+
     /// Checks the types of the provided `hir` and mutates them if needed. Any that could not be inferred but, yet is valid, is
     /// at the end, returned as it's default type. Returns the type module to be used on the next steps
     pub fn check(hir: &mut SlynxHir) -> Result<TypesModule> {
@@ -65,24 +102,6 @@ impl TypeChecker {
         self.types.insert(id, ty);
     }
 
-    /// Returns a reference to a struct based on the provided `id` which is expected to be the id of a VarReference type.
-    /// This returns a reference type to an object type.
-    fn retrieve_reference_of(&self, id: &VariableId, span: &Span) -> Result<HirType, TypeError> {
-        if let Some(v) = self.types_module.get_variable(id) {
-            let ty = self.types_module.get_type(v);
-            match ty {
-                HirType::Reference { .. } => Ok(ty.clone()),
-                HirType::VarReference(id) => self.retrieve_reference_of(id, span),
-                _ => Err(TypeError {
-                    kind: TypeErrorKind::NotARef(*id, ty.clone()),
-                    span: span.clone(),
-                }),
-            }
-        } else {
-            unreachable!("Type should have been determined");
-        }
-    }
-
     /// Resolves recursively the names of the types. If A -> B, B -> int; then we assume that A -> int
     fn resolve(&mut self, ty: &TypeId, span: &Span) -> Result<TypeId> {
         let referedty = self.types_module.get_type(ty).clone();
@@ -104,17 +123,15 @@ impl TypeChecker {
                 }
             }
             HirType::Field(FieldMethod::Variable(var_id, n)) => {
-                let HirType::Reference { rf, .. } = self.retrieve_reference_of(&var_id, span)?
-                else {
-                    unreachable!();
-                };
                 let object_ty = *self.types_module.get_variable(&var_id).ok_or(TypeError {
                     kind: TypeErrorKind::Unrecognized,
                     span: span.clone(),
                 })?;
-
-                let concrete_type = self.types_module.get_type(&rf);
-                let s_fields = self.structs.get(&object_ty).ok_or(TypeError {
+                let layout_ty = self.get_object_layout_type(&object_ty, span)?;
+                let concrete_type = self
+                    .types_module
+                    .get_type(&self.get_struct_from_ref(&object_ty, span)?);
+                let s_fields = self.structs.get(&layout_ty).ok_or(TypeError {
                     kind: TypeErrorKind::Unrecognized,
                     span: span.clone(),
                 })?;
@@ -619,5 +636,29 @@ mod tests {
             "expected IncompatibleTypes, got {:?}",
             type_error.kind
         );
+    }
+
+    #[test]
+    fn resolves_field_access_for_variables_typed_via_alias() {
+        let mut hir = load_hir_from_source(
+            r#"
+            object Person {
+                age: int,
+            }
+
+            alias PersonAlias = Person;
+
+            func make_person(): PersonAlias {
+                Person(age: 22)
+            }
+
+            func main(): int {
+                let person = make_person();
+                person.age
+            }
+            "#,
+        );
+
+        TypeChecker::check(&mut hir).expect("field access should resolve through aliases");
     }
 }

--- a/frontend/src/monomorphizer/mod.rs
+++ b/frontend/src/monomorphizer/mod.rs
@@ -1,7 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+
+use color_eyre::eyre::Result;
 
 use crate::hir::{
     SlynxHir, TypeId,
+    error::{HIRError, HIRErrorKind},
     types::{HirType, TypesModule},
 };
 
@@ -11,12 +14,12 @@ pub struct Monomorphizer {
 }
 
 impl Monomorphizer {
-    pub fn resolve(hir: &mut SlynxHir, types_module: &mut TypesModule) {
+    pub fn resolve(hir: &SlynxHir, types_module: &mut TypesModule) -> Result<()> {
         let mut this = Self {
             reference_cache: HashMap::new(),
         };
         for decl in hir.declarations.iter() {
-            this.resolve_reference(decl.ty, types_module)
+            this.resolve_reference(hir, decl.ty, decl.span.clone(), types_module)?;
         }
         for (key, value) in this.reference_cache {
             let HirType::Reference { rf, .. } = types_module.get_type_mut(&key) else {
@@ -24,18 +27,87 @@ impl Monomorphizer {
             };
             *rf = value;
         }
+        Ok(())
     }
     /// Resolves a reference. If the provided `id` is a reference to a concrete type, doesnt do anything, otherwise(thus, a reference)
     /// to another reference) it resolves it to make the reference point to the concrete type. This only caches it for later mutability
-    pub fn resolve_reference(&mut self, id: TypeId, types_module: &TypesModule) {
+    pub fn resolve_reference(
+        &mut self,
+        hir: &SlynxHir,
+        id: TypeId,
+        span: common::ast::Span,
+        types_module: &TypesModule,
+    ) -> Result<()> {
         let mut current = id;
+        let mut visited = HashSet::from([id]);
         while let HirType::Reference { rf, .. } = types_module.get_type(&current)
             && let HirType::Reference { .. } = types_module.get_type(rf)
         {
+            if !visited.insert(*rf) {
+                let ty = types_module
+                    .get_type_name(&id)
+                    .map(|symbol| hir.symbols_module.get_name(*symbol).to_string())
+                    .unwrap_or_else(|| format!("type id {}", id.as_raw()));
+
+                return Err(HIRError {
+                    kind: HIRErrorKind::RecursiveType { ty },
+                    span,
+                }
+                .into());
+            }
             current = *rf;
         }
         if current != id {
             self.reference_cache.insert(id, current);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Monomorphizer;
+    use crate::{
+        checker::TypeChecker,
+        hir::{
+            SlynxHir,
+            error::{HIRError, HIRErrorKind},
+        },
+        lexer::Lexer,
+        parser::Parser,
+    };
+
+    fn load_hir_from_source(source: &str) -> SlynxHir {
+        let tokens = Lexer::tokenize(source).expect("source should tokenize");
+        let declarations = Parser::new(tokens)
+            .parse_declarations()
+            .expect("source should parse");
+        let mut hir = SlynxHir::new();
+        hir.generate(declarations).expect("HIR should generate");
+        hir
+    }
+
+    #[test]
+    fn rejects_cyclic_aliases_in_monomorphization() {
+        let mut hir = load_hir_from_source(
+            r#"
+            alias A = B;
+            alias B = A;
+
+            func main(): void {}
+            "#,
+        );
+        let mut types_module = TypeChecker::check(&mut hir).expect("type checking should pass");
+
+        let err = Monomorphizer::resolve(&hir, &mut types_module)
+            .expect_err("cyclic aliases should fail during monomorphization");
+        let hir_error = err
+            .downcast_ref::<HIRError>()
+            .expect("error should come from the HIR layer");
+
+        match &hir_error.kind {
+            HIRErrorKind::RecursiveType { ty } => assert_eq!(ty, "A"),
+            other => panic!("expected RecursiveType, got {other:?}"),
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -353,7 +353,25 @@ impl SlynxContext {
             },
             Ok(module) => module,
         };
-        Monomorphizer::resolve(&mut hir, &mut types_module);
+        if let Err(e) = Monomorphizer::resolve(&hir, &mut types_module) {
+            match e.downcast_ref::<HIRError>() {
+                Some(err) => {
+                    let suggestion = suggestions_from_hir(err);
+                    let (line, column, src) = self.get_line_info(&self.entry_point, err.span.start);
+                    let err = SlynxError {
+                        line,
+                        column_start: column,
+                        ty: SlynxErrorType::Hir,
+                        message: e.to_string(),
+                        suggestion,
+                        file: self.entry_point.to_string_lossy().to_string(),
+                        source_code: src.to_string(),
+                    };
+                    return Err(e.wrap_err(err));
+                }
+                None => return Err(e),
+            }
+        }
         let variable_names = hir.variable_names().clone();
         let mut ir = SlynxIR::new(hir.symbols_module);
 


### PR DESCRIPTION
## Summary
- fix field access resolution for variables whose types come through aliases
- detect cyclic type aliases during monomorphization instead of looping indefinitely
- remove the stray debug `println!` from field-access checking
- surface monomorphizer alias-cycle failures through the existing `SlynxContext` HIR error path
- add regressions for alias-backed field access and cyclic aliases

## Why This Matters
PR #100 added type aliases, but it left two follow-up issues in the current pipeline:

1. field access could still consult object-field metadata through the alias type id instead of the underlying object layout
2. cyclic aliases could loop forever in the monomorphizer

This keeps the fix small and local to checker/monomorphizer behavior without expanding alias semantics beyond what `main` already supports.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p frontend --lib --no-run`
- `cargo test --lib -p slynx --no-run`
- `git diff --check`

## Local Test Note
I also compiled and attempted to run the two new targeted frontend tests locally while iterating:
- `resolves_field_access_for_variables_typed_via_alias`
- `rejects_cyclic_aliases_in_monomorphization`

The binaries compile, but executable test runs on this machine are still blocked by Windows App Control (`os error 4551`).
