### PR TITLE
Feat: expose compilation stage dumps

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -63,6 +63,13 @@ pub struct CompilationOutput {
     ir: SlynxIR,
 }
 
+#[derive(Debug)]
+pub struct CompilationStages {
+    entry_point: PathBuf,
+    hir_dump: String,
+    ir: SlynxIR,
+}
+
 impl CompilationOutput {
     ///Creates a new compilation output with the provided `ir`. Writes the `ir` in its textual format on the provided `entry_point` with extension of `sir`
     fn new(entry_point: &Path, ir: SlynxIR) -> Self {
@@ -86,6 +93,42 @@ impl CompilationOutput {
     pub fn write(&self) -> Result<()> {
         std::fs::write(&self.output_path, format!("{:#?}", self.ir))?;
         Ok(())
+    }
+}
+
+impl CompilationStages {
+    fn new(entry_point: &Path, hir_dump: String, ir: SlynxIR) -> Self {
+        Self {
+            entry_point: entry_point.to_path_buf(),
+            hir_dump,
+            ir,
+        }
+    }
+
+    pub fn hir_text(&self) -> &str {
+        &self.hir_dump
+    }
+
+    pub fn ir_text(&self) -> String {
+        format!("{:#?}", self.ir)
+    }
+
+    pub fn dump_path(&self, extension: &str) -> PathBuf {
+        self.entry_point.with_extension(extension)
+    }
+
+    pub fn write_hir(&self) -> Result<()> {
+        std::fs::write(self.dump_path("hir"), self.hir_text())?;
+        Ok(())
+    }
+
+    pub fn write_ir(&self) -> Result<()> {
+        std::fs::write(self.dump_path("ir"), self.ir_text())?;
+        Ok(())
+    }
+
+    pub fn into_output(self) -> CompilationOutput {
+        CompilationOutput::new(&self.entry_point, self.ir)
     }
 }
 
@@ -260,8 +303,9 @@ impl SlynxContext {
         }
     }
 
-    ///Compiles the code from the current contexts and returns the compilation result including the IR
-    pub fn compile(self) -> Result<CompilationOutput> {
+    ///Builds typed HIR and IR once so callers can inspect or persist intermediate dumps
+    ///before materializing the default `.sir` output.
+    pub fn build_stages(self) -> Result<CompilationStages> {
         let stream = match Lexer::tokenize(self.get_entry_point_source()) {
             Ok(value) => value,
             Err(e) => {
@@ -393,6 +437,7 @@ impl SlynxContext {
                 None => return Err(e),
             }
         }
+        let hir_dump = format_hir_dump(&hir, &types_module);
         let variable_names = hir.variable_names().clone();
         let mut ir = SlynxIR::new(hir.symbols_module);
 
@@ -407,8 +452,17 @@ impl SlynxContext {
                 )
                 .into());
         };
-        let output = CompilationOutput::new(self.entry_point.as_ref(), ir);
-        Ok(output)
+        Ok(CompilationStages::new(
+            self.entry_point.as_ref(),
+            hir_dump,
+            ir,
+        ))
+    }
+
+    ///Compiles the code from the current contexts and returns the compilation result including the IR
+    pub fn compile(self) -> Result<CompilationOutput> {
+        let stages = self.build_stages()?;
+        Ok(stages.into_output())
     }
 
     pub fn start_compilation(self) -> Result<()> {
@@ -416,6 +470,16 @@ impl SlynxContext {
         output.write()?;
         Ok(())
     }
+}
+
+fn format_hir_dump(hir: &SlynxHir, types_module: &TypesModule) -> String {
+    format!(
+        "HIR Declarations:\n{:#?}\n\nDeclarations Module:\n{:#?}\n\nTypes Module:\n{:#?}\n\nVariable Names:\n{:#?}",
+        hir.declarations,
+        hir.declarations_module,
+        types_module,
+        hir.variable_names()
+    )
 }
 
 fn format_ir_generation_error(

--- a/tests/compilation_output.rs
+++ b/tests/compilation_output.rs
@@ -60,3 +60,51 @@ fn compile_code_still_writes_js_output() {
 
     fs::remove_dir_all(case_dir).expect("temp case dir should be removed");
 }
+
+#[test]
+fn build_stages_exposes_hir_and_ir_dumps_without_writing_files() {
+    let case_dir = temp_case_dir("build-stages");
+    let source_path = write_temp_source(&case_dir);
+    let hir_path = source_path.with_extension("hir");
+    let ir_path = source_path.with_extension("ir");
+
+    let context = SlynxContext::new(Arc::new(source_path)).expect("context should be created");
+    let stages = context.build_stages().expect("stages should build");
+
+    assert_eq!(stages.dump_path("hir"), hir_path);
+    assert_eq!(stages.dump_path("ir"), ir_path);
+    assert!(stages.hir_text().contains("HIR Declarations"));
+    assert!(!stages.ir_text().is_empty());
+    assert!(!hir_path.exists());
+    assert!(!ir_path.exists());
+
+    fs::remove_dir_all(case_dir).expect("temp case dir should be removed");
+}
+
+#[test]
+fn build_stages_can_write_hir_ir_and_sir_outputs() {
+    let case_dir = temp_case_dir("dump-files");
+    let source_path = write_temp_source(&case_dir);
+    let hir_path = source_path.with_extension("hir");
+    let ir_path = source_path.with_extension("ir");
+    let sir_path = source_path.with_extension("sir");
+
+    let context = SlynxContext::new(Arc::new(source_path)).expect("context should be created");
+    let stages = context.build_stages().expect("stages should build");
+
+    stages.write_hir().expect("hir dump should be written");
+    stages.write_ir().expect("ir dump should be written");
+    let output = stages.into_output();
+    output.write().expect("sir output should be written");
+
+    for path in [&hir_path, &ir_path, &sir_path] {
+        assert!(path.exists(), "{} should exist", path.display());
+        assert!(
+            !fs::read_to_string(path)
+                .expect("generated dump should be readable")
+                .is_empty()
+        );
+    }
+
+    fs::remove_dir_all(case_dir).expect("temp case dir should be removed");
+}


### PR DESCRIPTION
## Summary
- add `SlynxContext::build_stages()` so the typed HIR and IR can be built once and inspected before the default `.sir` write path
- add a new `CompilationStages` value with:
  - `hir_text()`
  - `ir_text()`
  - `dump_path()`
  - `write_hir()`
  - `write_ir()`
  - `into_output()`
- keep the current `compile()` / `.sir` flow intact by making it wrap `build_stages()` internally
- add regression coverage for stage dumps and writing `.hir`, `.ir`, and `.sir` side-by-side

## Why This Matters
Issue #52 asks for a way to inspect intermediate compiler stages without recompiling the whole pipeline from scratch.

This PR takes the smallest useful slice of that idea:
- the library can now build stages once
- callers can persist `.hir` and `.ir` dumps from that stage state
- the existing `.sir` output path stays unchanged

I intentionally kept CLI flags out of this PR so the review stays focused on the stage/dump API first.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test compilation_output --no-run`
- `cargo test --lib --no-run`
- `git diff --check`

## Local Test Note
On this Windows machine, executable test runs are still intermittently blocked by App Control (`os error 4551`), so the new regression was validated with `--no-run` locally and should be fully exercised by CI.

## Related Issues
- Part of #52
