### PR TITLE
Docs: refresh repository-facing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Slynx is still experimental and under active design.
 What is true on the current `main` branch:
 
 - the workspace is library-first; there is no official CLI binary target in `main` right now
-- the root crate can lex, parse, build HIR, run type checking, and lower source files into `IntermediateRepr`
-- the root library can write the current IR output to a sibling `.sir` file
+- the root crate can lex, parse, build HIR, run type checking, resolve the current alias surface, and lower source files into `SlynxIR`
+- the root library can write the default `.sir` output and can expose `.hir` / `.ir` dumps through `SlynxContext::build_stages()`
 - sample `.slynx` sources live under [`slynx/`](slynx)
 - the IR design is still evolving, and the design reference in [`middleend/README.md`](middleend/README.md) is broader than what `main` emits today
 
@@ -25,17 +25,18 @@ The repository is currently split into these crates:
 
 - [`common/`](common): shared AST types and common language data structures
 - [`frontend/`](frontend): lexer, parser, HIR generation, and type checking
-- [`middleend/`](middleend): `IntermediateRepr` and IR/lowering work
+- [`middleend/`](middleend): `SlynxIR` and IR/lowering work
 - [`src/`](src): root library glue (`SlynxContext`, compile helpers, error presentation)
 
 ## What Exists Today
 
 The current codebase already includes:
 
-- lexical analysis and parsing for core language constructs such as functions, objects, components, and basic control flow
+- lexical analysis and parsing for core language constructs such as functions, objects, components, aliases, tuple literals/types, and control flow such as `if` and `while`
 - HIR generation and name resolution
-- type checking and type inference for the current supported surface
-- lowering to the current `IntermediateRepr`
+- type checking, type inference, and monomorphization for the current supported alias surface
+- library entry points for compiling to IR or inspecting HIR/IR dumps before writing output
+- lowering to the current `SlynxIR`
 - CI, release, governance, and contribution documentation
 
 The current repository does **not** ship an official backend crate or an official CLI binary on `main`.
@@ -72,11 +73,41 @@ fn main() -> color_eyre::eyre::Result<()> {
 }
 ```
 
-If you want to write the current IR output to disk, use `slynx::compile_code(...)` or `SlynxContext::start_compilation(...)`. The output is written next to the input file with the `.sir` extension.
+If you want to inspect intermediate dumps before writing output, the root context also exposes stage building:
 
-## Example Source
+```rust
+use std::{path::PathBuf, sync::Arc};
 
-A small sample that matches the current repository syntax lives in [`slynx/component.slynx`](slynx/component.slynx):
+fn main() -> color_eyre::eyre::Result<()> {
+    let context = slynx::SlynxContext::new(Arc::new(PathBuf::from("slynx/booleans.slynx")))?;
+    let stages = context.build_stages()?;
+
+    println!("{}", stages.hir_text());
+    stages.write_hir()?;
+    stages.write_ir()?;
+
+    let output = stages.into_output();
+    output.write()?;
+    Ok(())
+}
+```
+
+Today:
+
+- `compile_code(...)` and `SlynxContext::start_compilation(...)` write the default sibling `.sir` file
+- `build_stages()` lets callers inspect or persist `.hir` and `.ir` dumps through the library API
+- there is still no polished CLI workflow for dump generation on `main`
+
+## Example Sources
+
+Real samples that match the current repository syntax live under [`slynx/`](slynx), for example:
+
+- [`slynx/component.slynx`](slynx/component.slynx): basic component construction
+- [`slynx/objects.slynx`](slynx/objects.slynx): object construction and field mutation
+- [`slynx/while.slynx`](slynx/while.slynx): `while` loops
+- [`slynx/functioncall.slynx`](slynx/functioncall.slynx): typed function calls
+
+One small component example:
 
 ```slynx
 

--- a/docs/first-slynx-file.md
+++ b/docs/first-slynx-file.md
@@ -114,6 +114,34 @@ This combines:
 - `if` as an expression;
 - component construction.
 
+## What Else `main` Already Supports
+
+This guide stays intentionally small, but the current repository surface already
+includes a few other useful pieces:
+
+- `while` loops inside function bodies;
+- top-level `alias` declarations;
+- tuple types such as `(int, str)`;
+- tuple literals such as `(1, "ok")`;
+- zero-argument calls such as `ping()`.
+
+Examples:
+
+```slynx
+alias PersonAlias = Person;
+
+func pair(): (int, str) {
+    (1, "ok")
+}
+
+func tick(): void {
+    let mut x = 0;
+    while x < 10 {
+        x = x + 1;
+    }
+}
+```
+
 ## Current Rules Worth Remembering
 
 - function calls use parentheses: `sum(1, 2)`
@@ -121,7 +149,32 @@ This combines:
 - objects use named fields in parentheses: `Person(name: "A", age: 1)`
 - components use braces: `ProfileCard {}`
 - field access uses dot syntax: `person.age`
+- aliases are top-level declarations: `alias Name = OtherType;`
+- tuple types use parentheses: `(int, str)`
+- tuple literals use parentheses and commas: `(1, "ok")`
 - non-final statements in a block still need `;`
+
+## Inspecting HIR And IR While Learning
+
+If you want to read the compiler output while learning the codebase, the root
+library already exposes dump generation through `SlynxContext::build_stages()`.
+
+```rust
+use std::{path::PathBuf, sync::Arc};
+
+fn main() -> color_eyre::eyre::Result<()> {
+    let context = slynx::SlynxContext::new(Arc::new(PathBuf::from("slynx/booleans.slynx")))?;
+    let stages = context.build_stages()?;
+
+    println!("{}", stages.hir_text());
+    stages.write_hir()?;
+    stages.write_ir()?;
+    Ok(())
+}
+```
+
+That is useful for contributors reading parser/HIR/type-checker changes without
+depending on a CLI binary.
 
 ## What This Guide Does Not Promise
 
@@ -130,6 +183,7 @@ This guide is intentionally limited to the syntax that is already grounded on
 
 It does **not** document as finished:
 
+- tuple access or tuple destructuring;
 - slots;
 - reactive graphs;
 - finalized child lowering in the IR;

--- a/docs/landing-content-inventory.md
+++ b/docs/landing-content-inventory.md
@@ -46,8 +46,8 @@ Safe claims today:
 - Slynx is an experimental UI language project
 - the current repository is library-first
 - the current workspace is focused on the frontend and middleend of the language
-- `main` can lex, parse, build HIR, run type checking, and lower to the current `IntermediateRepr`
-- the root crate can write the current IR output to a sibling `.sir` file
+- `main` can lex, parse, build HIR, run type checking, resolve the current alias surface, and lower to the current `SlynxIR`
+- the root crate can write the default `.sir` output and can expose `.hir` / `.ir` dumps through `SlynxContext::build_stages()`
 
 Evidence:
 
@@ -70,7 +70,7 @@ Safe content:
 
 - `common/`: shared AST and common language structures
 - `frontend/`: lexer, parser, HIR generation, and type checking
-- `middleend/`: current IR/lowering work
+- `middleend/`: current `SlynxIR` and IR/lowering work
 - root crate: compile helpers, context, and error presentation
 
 Evidence:
@@ -108,14 +108,17 @@ Status: `Implemented`
 Safe content:
 
 - top-level `object`, `component`, and `func` declarations
+- top-level `alias` declarations
 - block-bodied and arrow-bodied functions
 - `let` / `let mut`
 - assignment
+- `while`
 - function calls, including zero-argument calls
+- tuple types and tuple literals
 - object expressions
 - component expressions
 - field access
-- arithmetic/comparison/logical binary expressions
+- arithmetic/comparison/logical/bitwise binary expressions
 - `if` expressions
 
 Evidence:
@@ -133,6 +136,9 @@ Safe content:
 - `slynx::compile_code(...)`
 - `slynx::compile_to_ir(...)`
 - `SlynxContext`
+- `SlynxContext::build_stages()`
+- `CompilationStages`
+- `.hir` / `.ir` dump writing through the library API
 - public module re-exports for `checker`, `hir`, `lexer`, and `parser`
 
 Evidence:
@@ -143,8 +149,9 @@ Evidence:
 Important limitation:
 
 - there is not yet a polished, versioned API reference for the whole project
+- the dump outputs are still debug-style textual artifacts, not a stable versioned public format
 - landing content can mention the public entry points, but should not pretend a complete API
-  reference already exists
+  reference or polished CLI workflow already exists
 
 ### 6. Governance / Community / Releases
 
@@ -236,7 +243,8 @@ These topics should not be published as current product features:
 
 - official CLI binary on `main`
 - official backend compiler on `main`
-- stable textual `.hir` / `.ir` artifact generation on `main`
+- polished CLI flags/workflow for dump generation on `main`
+- stable versioned textual `.hir` / `.ir` dump contracts
 - implemented component slots
 - implemented reactive graph lowering
 - stable generics / monomorphization pipeline
@@ -269,7 +277,7 @@ Good candidates to turn into landing/docs pages now:
 
 Start small and honest:
 
-- root helpers: `compile_code`, `compile_to_ir`, `SlynxContext`
+- root helpers: `compile_code`, `compile_to_ir`, `SlynxContext`, `build_stages`
 - note that broader API reference is still incomplete
 
 ### Features
@@ -279,7 +287,9 @@ Only present features with strict wording:
 - lexer + parser
 - HIR generation
 - type checking
-- lowering to current `IntermediateRepr`
+- lowering to current `SlynxIR`
+- aliases, tuple literals/types, and `while` in the current frontend surface
+- library-side `.hir` / `.ir` / `.sir` dump generation
 - CI + release/tag workflow
 
 Avoid broad claims like:

--- a/docs/language-surface.md
+++ b/docs/language-surface.md
@@ -3,9 +3,10 @@
 This document describes the language surface that is currently supported on the
 `main` branch of `Slynx-Language/slynx`.
 
-It is intentionally scoped to what the repository can already lex, parse, and
-type-check today. It should be safe to reuse this document on the landing page
-or docs site without marketing unfinished features as already available.
+It is intentionally scoped to what the repository can already lex, parse,
+lower into HIR, and type-check today. It should be safe to reuse this document
+on the landing page or docs site without marketing unfinished features as
+already available.
 
 ## Status
 
@@ -16,8 +17,9 @@ It does **not** try to document:
 - slot syntax as implemented code;
 - reactive graph lowering as implemented code;
 - generics as a finished language feature;
+- tuple access or tuple destructuring as implemented code;
 - a stable public CLI workflow;
-- a stable backend/output contract beyond the current `.sir` output.
+- a stable backend or IR contract beyond the current debug-style dumps.
 
 For design-only topics, see:
 
@@ -27,11 +29,12 @@ For design-only topics, see:
 
 ## Top-Level Declarations
 
-The current parser accepts three top-level declaration kinds:
+The current parser accepts four top-level declaration kinds:
 
 - `object`
 - `component`
 - `func`
+- `alias`
 
 Example:
 
@@ -40,6 +43,8 @@ object Person {
     name: str,
     age: int,
 }
+
+alias PersonRef = Person;
 
 component Profile {
     Text {
@@ -91,6 +96,7 @@ Inside function bodies, the current frontend supports:
 - immutable `let`;
 - mutable `let mut`;
 - assignment;
+- `while`;
 - expression statements.
 
 Example:
@@ -121,6 +127,80 @@ func main(): int {
 }
 ```
 
+### While
+
+`while` is now part of the grounded frontend surface on `main`.
+
+Example:
+
+```slynx
+func main(): void {
+    let mut x = 0;
+    while x < 10 {
+        x = x + 1;
+    }
+}
+```
+
+Notes:
+
+- the condition is type-checked as `bool`;
+- statements inside the body are also type-checked;
+- this document only claims the current frontend support, not a finalized
+  runtime/backend contract.
+
+## Types, Aliases, and Tuples
+
+The current surface includes built-in types such as `int`, `float`, `bool`,
+`str`, `void`, and `Component`, plus named object/component types declared in
+source.
+
+### Aliases
+
+Top-level aliases use `alias`:
+
+```slynx
+object Person {
+    age: int,
+}
+
+alias PersonAlias = Person;
+
+func main(): PersonAlias {
+    Person(age: 22)
+}
+```
+
+This is already part of the parser/HIR/checker pipeline on `main`.
+
+### Tuple Types
+
+Tuple types use parentheses:
+
+```slynx
+func pair(): (int, str) {
+    (1, "ok")
+}
+```
+
+The empty tuple type is also recognized as `()`.
+
+### Tuple Literals
+
+Tuple literals are currently parsed, lowered, and type-checked:
+
+```slynx
+func pair(): ((int, str), float) {
+    ((1, "jorge"), 1.0)
+}
+```
+
+Important limitation:
+
+- tuple access such as `value.0` is **not** implemented as finished behavior on
+  `main` yet;
+- tuple destructuring should also be treated as unfinished.
+
 ## Expressions
 
 The current surface includes:
@@ -131,6 +211,7 @@ The current surface includes:
 - boolean literals;
 - identifiers;
 - function calls;
+- tuple literals;
 - object expressions;
 - component expressions;
 - field access;
@@ -146,9 +227,12 @@ let s = "hello";
 let ok = true;
 ```
 
+Numeric separators are also accepted in numeric literals today, as long as the
+placement is valid for the lexer.
+
 ### Function Calls
 
-Function calls use parentheses and now accept zero or more arguments.
+Function calls use parentheses and accept zero or more arguments.
 
 ```slynx
 func ping(): int -> 0;
@@ -161,7 +245,8 @@ func main(): int {
 
 ### Binary Expressions
 
-The current parser supports arithmetic, comparison, and logical operators.
+The current parser supports arithmetic, comparison, logical, and bitwise binary
+operators.
 
 Examples already covered by the codebase include:
 
@@ -176,6 +261,11 @@ Examples already covered by the codebase include:
 - `<=`
 - `&&`
 - `||`
+- `&`
+- `|`
+- `^`
+- `<<`
+- `>>`
 
 Example:
 
@@ -290,12 +380,13 @@ func main(): int -> 0;
 These topics are still being discussed or implemented and should not be read as
 finished language surface:
 
-- `while` as a fully merged feature on `main`;
 - slot syntax as implemented code;
+- tuple access or tuple destructuring;
 - final child representation in the IR;
 - reactive graph lowering;
 - generic-specialized component lowering;
-- finalized backend semantics.
+- finalized backend semantics;
+- a polished CLI workflow for dump generation.
 
 ## Practical Reading
 
@@ -307,3 +398,5 @@ start here:
 - [slynx/functioncall.slynx](../slynx/functioncall.slynx)
 - [slynx/objects.slynx](../slynx/objects.slynx)
 - [slynx/If.slynx](../slynx/If.slynx)
+- [slynx/while.slynx](../slynx/while.slynx)
+- [slynx/tuplas.sly](../slynx/tuplas.sly)

--- a/middleend/README.md
+++ b/middleend/README.md
@@ -10,9 +10,10 @@ This file mixes current behavior and planned IR design.
 
 What is true today:
 
-- the current `main` branch lowers source into `IntermediateRepr`
-- the root crate currently writes `.sir` output using Rust debug-style serialization
+- the current `main` branch lowers source into `SlynxIR`
+- the root crate writes `.sir` output by default and can also expose `.hir` / `.ir` dumps through `SlynxContext::build_stages()`
 - not every construct documented below is emitted by the current codebase yet
+- the current textual dump format is still Rust debug-style output, not a stable versioned public contract
 - when this document and the code disagree about present behavior, treat the code as the source of truth and this file as the target shape the project is moving toward
 
 The long-term goal is an SSA-oriented, strongly typed IR that tells a downstream compiler what to do without forcing a single runtime strategy.
@@ -59,7 +60,9 @@ object S {
 }
 ```
 
-Tuples(WIP) use the same method, so a tuple in slynx denotated by
+Tuple literals and tuple types now exist in the frontend surface, but tuple-specific
+IR behavior is still being worked out. The intended representation uses the same
+method, so a tuple in slynx denotated by
 ```slynx
 object T(int,float);
 ```


### PR DESCRIPTION
## Summary
- refresh the repository-facing docs so they match the current `main` branch behavior
- document the current `SlynxIR` / `build_stages()` / `.hir` / `.ir` / `.sir` story without pretending there is already a polished CLI
- update the grounded language docs to include aliases, tuple literals/types, and `while`, while still marking tuple access, slots, and reactive lowering as unfinished
- align the middleend status section and landing-content inventory with the current library-first workflow

## Why This Matters
The repo docs had drifted behind recent merges.

In particular, they still described `IntermediateRepr`, did not mention the merged stage-dump API, and still treated pieces like `while`, aliases, and tuple literals/types as if they were not part of the grounded `main`-branch surface yet.

This PR keeps the docs honest in both directions:
- it updates what is already true on `main`
- it keeps future-facing topics clearly labeled as spec/design or unfinished work

## Validation
- `git diff --check`
- `cargo test --no-run`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
