### PR TITLE
Feat: add minimal CLI stage dump flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 **/target/
-src/main.rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,56 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,46 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "clap"
-version = "4.5.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8120877db0e5c011242f96806ce3c94e0737ab8108532a76a3300a01db2ab8"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02576b399397b659c26064fbc92a75fede9d18ffd5f80ca1cd74ddab167016e1"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
-
-[[package]]
 name = "color-eyre"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,12 +70,6 @@ dependencies = [
  "tracing-core",
  "tracing-error",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "common"
@@ -200,22 +104,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "lazy_static"
@@ -279,12 +171,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "owo-colors"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,24 +187,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "proc-macro2"
-version = "1.0.103"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
-dependencies = [
- "proc-macro2",
-]
 
 [[package]]
 name = "rart"
@@ -369,7 +237,6 @@ dependencies = [
 name = "slynx"
 version = "0.1.0"
 dependencies = [
- "clap",
  "color-eyre",
  "common",
  "frontend",
@@ -381,23 +248,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "syn"
-version = "2.0.110"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "thread_local"
@@ -450,18 +300,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,12 +310,3 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ smallvec = "1.15.1"
 color-eyre = "0.6.5"
 
 [dependencies]
-clap = { version = "4.5.52", features = ["derive"] }
 color-eyre={workspace=true}
 middleend = {path="./middleend"}
 frontend = {path="./frontend"}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,98 @@
+use std::{env, ffi::OsString, path::PathBuf, sync::Arc};
+
+use color_eyre::{
+    Result,
+    eyre::{bail, eyre},
+};
+use slynx::SlynxContext;
+
+#[derive(Debug, Default)]
+struct CliArgs {
+    target: Option<PathBuf>,
+    hir: bool,
+    ir: bool,
+}
+
+impl CliArgs {
+    fn parse() -> Result<Self> {
+        let mut parsed = Self::default();
+        let mut args = env::args_os();
+        let program_name = args.next().unwrap_or_else(|| OsString::from("slynx"));
+
+        while let Some(arg) = args.next() {
+            match arg.to_string_lossy().as_ref() {
+                "--hir" => parsed.hir = true,
+                "--ir" => parsed.ir = true,
+                "--target" | "-t" => {
+                    let value = args.next().ok_or_else(|| {
+                        eyre!("expected a file path after {}", arg.to_string_lossy())
+                    })?;
+                    parsed.set_target(PathBuf::from(value))?;
+                }
+                "--help" | "-h" => {
+                    Self::print_help(&program_name);
+                    std::process::exit(0);
+                }
+                flag if flag.starts_with('-') => {
+                    bail!("unrecognized flag: {flag}");
+                }
+                _ => {
+                    // Accept a positional file path so the CLI stays easy to use in addition
+                    // to supporting the explicit --target form requested by the issue.
+                    parsed.set_target(PathBuf::from(arg))?;
+                }
+            }
+        }
+
+        if parsed.target.is_none() {
+            Self::print_help(&program_name);
+            bail!("missing target file. Use --target <path> or pass the path positionally");
+        }
+
+        Ok(parsed)
+    }
+
+    fn set_target(&mut self, target: PathBuf) -> Result<()> {
+        if self.target.is_some() {
+            bail!("target file was provided more than once");
+        }
+        self.target = Some(target);
+        Ok(())
+    }
+
+    fn print_help(program_name: &OsString) {
+        eprintln!(
+            "Usage: {} [--target <path> | <path>] [--hir] [--ir]\n\n\
+             Options:\n  \
+             -t, --target <path>  Input .slynx file to compile\n  \
+             --hir                Write the textual HIR dump next to the input as .hir\n  \
+             --ir                 Write the textual IR dump next to the input as .ir\n  \
+             -h, --help           Show this help message",
+            program_name.to_string_lossy()
+        );
+    }
+}
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
+    let cli = CliArgs::parse()?;
+    let entry_point = Arc::new(cli.target.expect("target should be set during parsing"));
+
+    // Build the compiler stages once so optional dump flags do not rerun the pipeline.
+    let context = SlynxContext::new(entry_point)?;
+    let stages = context.build_stages()?;
+
+    if cli.hir {
+        stages.write_hir()?;
+    }
+
+    if cli.ir {
+        stages.write_ir()?;
+    }
+
+    // Keep the CLI aligned with the existing library behavior by always writing the .sir output.
+    let output = stages.into_output();
+    output.write()?;
+
+    Ok(())
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,75 @@
+use std::{
+    fs,
+    path::PathBuf,
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn temp_case_dir(name: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after unix epoch")
+        .as_nanos();
+    path.push(format!("slynx-cli-{name}-{}-{nonce}", std::process::id()));
+    path
+}
+
+fn write_temp_source(case_dir: &PathBuf) -> PathBuf {
+    // Copy a real fixture into a temp directory so CLI output files do not touch the repository.
+    fs::create_dir_all(case_dir).expect("temp case dir should be created");
+    let source_path = case_dir.join("input.slynx");
+    let source = fs::read_to_string("slynx/booleans.slynx").expect("fixture should exist");
+    fs::write(&source_path, source).expect("temp source should be written");
+    source_path
+}
+
+fn run_cli(args: &[&str]) {
+    let status = Command::new(env!("CARGO_BIN_EXE_slynx"))
+        .args(args)
+        .status()
+        .expect("cli should be executable");
+    assert!(status.success(), "cli should exit successfully");
+}
+
+#[test]
+fn cli_writes_sir_by_default() {
+    let case_dir = temp_case_dir("sir-default");
+    let source_path = write_temp_source(&case_dir);
+    let sir_path = source_path.with_extension("sir");
+
+    let source_arg = source_path.to_string_lossy().into_owned();
+    run_cli(&[&source_arg]);
+
+    assert!(sir_path.exists(), "{} should exist", sir_path.display());
+    assert!(
+        !fs::read_to_string(&sir_path)
+            .expect("sir output should be readable")
+            .is_empty()
+    );
+
+    fs::remove_dir_all(case_dir).expect("temp case dir should be removed");
+}
+
+#[test]
+fn cli_writes_optional_hir_and_ir_dumps() {
+    let case_dir = temp_case_dir("stage-dumps");
+    let source_path = write_temp_source(&case_dir);
+    let hir_path = source_path.with_extension("hir");
+    let ir_path = source_path.with_extension("ir");
+    let sir_path = source_path.with_extension("sir");
+
+    let source_arg = source_path.to_string_lossy().into_owned();
+    run_cli(&["--target", &source_arg, "--hir", "--ir"]);
+
+    for path in [&hir_path, &ir_path, &sir_path] {
+        assert!(path.exists(), "{} should exist", path.display());
+        assert!(
+            !fs::read_to_string(path)
+                .expect("generated dump should be readable")
+                .is_empty()
+        );
+    }
+
+    fs::remove_dir_all(case_dir).expect("temp case dir should be removed");
+}


### PR DESCRIPTION
## Summary
- add a minimal root CLI binary for compiling `.slynx` files from the repository package itself
- support optional `--hir` and `--ir` flags while keeping the existing `.sir` output as the default artifact
- add CLI integration coverage for both positional target paths and the explicit `--target` form requested by issue #52
- stop ignoring `src/main.rs` now that the repository has an official binary entrypoint

## Why This Matters
Issue #52 asks for a way to generate `.hir` and `.ir` files without reworking the compiler pipeline from scratch.

The stage-building API already landed in `#104`, so the clean next step is a very small CLI layer on top of that API. This PR does exactly that without expanding into a larger command surface, config format, or backend-specific workflow.

## Notes
- the CLI accepts either `slynx path/to/file.slynx` or `slynx --target path/to/file.slynx`
- `--hir` writes a sibling `.hir` dump
- `--ir` writes a sibling `.ir` dump
- `.sir` is still written every time so the CLI stays aligned with the existing library behavior
- I intentionally kept the PR code-focused; the broader repository docs refresh is already being handled separately in `#108`

## Validation
- `cargo fmt --all -- --check`
- `cargo test --test cli --no-run`
- `cargo test --no-run`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Local Environment Note
I also attempted to execute `cargo test --test cli -- --nocapture` locally, but Windows App Control blocked the produced test binary with `os error 4551`. The compile/no-run validation completed successfully, so the execution path is expected to be confirmed by CI.
