### PR TITLE
Feat: add tuple access and refine postfix parsing

### DIFF
--- a/frontend/src/checker/error.rs
+++ b/frontend/src/checker/error.rs
@@ -28,6 +28,13 @@ pub enum TypeErrorKind {
         expected: HirType,
         received: HirType,
     },
+    InvalidTupleAccessTarget {
+        received: HirType,
+    },
+    InvalidTupleIndex {
+        index: usize,
+        length: usize,
+    },
     InvalidFuncallArgLength {
         expected_length: usize,
         received_length: usize,
@@ -59,6 +66,14 @@ impl std::fmt::Display for TypeError {
             TypeErrorKind::IncompatibleTypes { expected, received } => format!(
                 "Incompatible types. Was expecting to receive type '{expected:?}' instead got type '{received:?}'"
             ),
+            TypeErrorKind::InvalidTupleAccessTarget { received } => {
+                format!("Type '{received:?}' does not support tuple-style access")
+            }
+            TypeErrorKind::InvalidTupleIndex { index, length } => {
+                format!(
+                    "Tuple index {index} is out of bounds. The tuple only exposes {length} fields"
+                )
+            }
             TypeErrorKind::InvalidFuncallArgLength {
                 expected_length,
                 received_length,

--- a/frontend/src/checker/expr.rs
+++ b/frontend/src/checker/expr.rs
@@ -44,6 +44,13 @@ impl TypeChecker {
                     .insert_unnamed_type(HirType::Field(FieldMethod::Type(rf, index)));
                 self.resolve(field_ty, span)
             }
+            FieldMethod::Tuple(rf, index) => {
+                *field_index = index;
+                *field_ty = self
+                    .types_module
+                    .insert_unnamed_type(HirType::Field(FieldMethod::Tuple(rf, index)));
+                self.resolve(field_ty, span)
+            }
             FieldMethod::Variable(variable_id, field_name) => {
                 // Field accesses first enter the checker attached to the source
                 // variable name. Resolve that symbolic access once and rewrite it
@@ -224,7 +231,8 @@ impl TypeChecker {
                 }
                 HirStatementKind::Assign { lhs, value } => {
                     let refty = match self.types_module.get_type(&lhs.ty) {
-                        HirType::Field(FieldMethod::Type(_, _)) => lhs.ty,
+                        HirType::Field(FieldMethod::Type(_, _))
+                        | HirType::Field(FieldMethod::Tuple(_, _)) => lhs.ty,
                         HirType::Field(FieldMethod::Variable(..)) => {
                             let HirExpressionKind::FieldAccess {
                                 ref mut field_index,

--- a/frontend/src/checker/mod.rs
+++ b/frontend/src/checker/mod.rs
@@ -68,6 +68,37 @@ impl TypeChecker {
         }
     }
 
+    fn resolve_tuple_index_type(
+        &mut self,
+        ty: &TypeId,
+        index: usize,
+        span: &Span,
+    ) -> Result<TypeId> {
+        // Tuple access stays explicit all the way to the checker so numeric
+        // postfixes never get confused with object field lookups.
+        let resolved_ty = self.resolve(ty, span)?;
+        let HirType::Tuple { fields } = self.types_module.get_type(&resolved_ty).clone() else {
+            return Err(TypeError {
+                kind: TypeErrorKind::InvalidTupleAccessTarget {
+                    received: self.types_module.get_type(&resolved_ty).clone(),
+                },
+                span: span.clone(),
+            }
+            .into());
+        };
+
+        fields.get(index).copied().ok_or(
+            TypeError {
+                kind: TypeErrorKind::InvalidTupleIndex {
+                    index,
+                    length: fields.len(),
+                },
+                span: span.clone(),
+            }
+            .into(),
+        )
+    }
+
     /// Checks the types of the provided `hir` and mutates them if needed. Any that could not be inferred but, yet is valid, is
     /// at the end, returned as it's default type. Returns the type module to be used on the next steps
     pub fn check(hir: &mut SlynxHir) -> Result<TypesModule> {
@@ -121,6 +152,9 @@ impl TypeChecker {
                     }
                     .into())
                 }
+            }
+            HirType::Field(FieldMethod::Tuple(rf, index)) => {
+                self.resolve_tuple_index_type(&rf, index, span)
             }
             HirType::Field(FieldMethod::Variable(var_id, n)) => {
                 let object_ty = *self.types_module.get_variable(&var_id).ok_or(TypeError {
@@ -681,5 +715,91 @@ mod tests {
         );
 
         TypeChecker::check(&mut hir).expect("field access should resolve through aliases");
+    }
+
+    #[test]
+    fn resolves_tuple_access_for_tuple_variables() {
+        let mut hir = load_hir_from_source(
+            r#"
+            func main(): int {
+                let pair = (10, 20);
+                pair.0
+            }
+            "#,
+        );
+
+        TypeChecker::check(&mut hir).expect("tuple access should resolve through the checker");
+    }
+
+    #[test]
+    fn resolves_named_field_access_after_tuple_access() {
+        let mut hir = load_hir_from_source(
+            r#"
+            object Person {
+                age: int,
+            }
+
+            func main(): int {
+                let pair = (Person(age: 22), "ok");
+                pair.0.age
+            }
+            "#,
+        );
+
+        TypeChecker::check(&mut hir)
+            .expect("named field access after tuple access should resolve cleanly");
+    }
+
+    #[test]
+    fn rejects_tuple_access_with_invalid_index() {
+        let mut hir = load_hir_from_source(
+            r#"
+            func main(): int {
+                let pair = (10, 20);
+                pair.2
+            }
+            "#,
+        );
+
+        let err =
+            TypeChecker::check(&mut hir).expect_err("tuple accesses should reject invalid indexes");
+        let type_error = err
+            .downcast_ref::<TypeError>()
+            .expect("error should come from type checker");
+
+        match &type_error.kind {
+            TypeErrorKind::InvalidTupleIndex { index, length } => {
+                assert_eq!(*index, 2);
+                assert_eq!(*length, 2);
+            }
+            other => panic!("expected InvalidTupleIndex, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_tuple_access_on_non_tuple_values() {
+        let mut hir = load_hir_from_source(
+            r#"
+            func main(): int {
+                let value = 10;
+                value.0
+            }
+            "#,
+        );
+
+        let err =
+            TypeChecker::check(&mut hir).expect_err("non-tuples should reject tuple-style access");
+        let type_error = err
+            .downcast_ref::<TypeError>()
+            .expect("error should come from type checker");
+
+        assert!(
+            matches!(
+                type_error.kind,
+                TypeErrorKind::InvalidTupleAccessTarget { .. }
+            ),
+            "expected InvalidTupleAccessTarget, got {:?}",
+            type_error.kind
+        );
     }
 }

--- a/frontend/src/hir/error.rs
+++ b/frontend/src/hir/error.rs
@@ -14,6 +14,16 @@ pub enum HIRErrorKind {
     TypeNotRecognized(String),
     NameNotRecognized(String),
     NameAlreadyDefined(String),
+    InvalidFieldAccessTarget {
+        ty: HirType,
+    },
+    InvalidTupleAccessTarget {
+        ty: HirType,
+    },
+    InvalidTupleIndex {
+        index: usize,
+        length: usize,
+    },
     InvalidBinaryExpression {
         lhs: Box<HirExpression>,
         rhs: Box<HirExpression>,
@@ -69,6 +79,17 @@ impl std::fmt::Display for HIRError {
             }
             HIRErrorKind::TypeNotRecognized(name) => {
                 format!("Type with name '{name}' is was not defined previously")
+            }
+            HIRErrorKind::InvalidFieldAccessTarget { ty } => {
+                format!("Type '{ty:?}' does not support field-style access")
+            }
+            HIRErrorKind::InvalidTupleAccessTarget { ty } => {
+                format!("Type '{ty:?}' does not support tuple-style access")
+            }
+            HIRErrorKind::InvalidTupleIndex { index, length } => {
+                format!(
+                    "Tuple index {index} is out of bounds. The tuple only exposes {length} fields"
+                )
             }
             HIRErrorKind::InvalidBinaryExpression { .. } => "Invalid binary expression".to_string(),
             HIRErrorKind::PropertyNotVisible { prop_name } => {

--- a/frontend/src/hir/implementation/expression.rs
+++ b/frontend/src/hir/implementation/expression.rs
@@ -103,6 +103,109 @@ impl SlynxHir {
         }
     }
 
+    fn resolve_tuple_access_type(&self, ty: TypeId, index: usize, span: &Span) -> Result<TypeId> {
+        // Follow the shape of the parent expression until we reach the concrete
+        // tuple type that owns the requested index.
+        let current_ty = self.types_module.get_type(&ty).clone();
+        match current_ty {
+            HirType::VarReference(variable_id) => {
+                let variable_ty = *self
+                    .types_module
+                    .get_variable(&variable_id)
+                    .expect("variable type should exist before tuple access lowering");
+                self.resolve_tuple_access_type(variable_ty, index, span)
+            }
+            HirType::Field(field_method) => {
+                let field_ty = self.resolve_field_method_type(&field_method, span)?;
+                self.resolve_tuple_access_type(field_ty, index, span)
+            }
+            HirType::Reference { rf, .. } => self.resolve_tuple_access_type(rf, index, span),
+            HirType::Tuple { fields } => fields.get(index).copied().ok_or(
+                HIRError {
+                    kind: HIRErrorKind::InvalidTupleIndex {
+                        index,
+                        length: fields.len(),
+                    },
+                    span: span.clone(),
+                }
+                .into(),
+            ),
+            other => Err(HIRError {
+                kind: HIRErrorKind::InvalidTupleAccessTarget { ty: other },
+                span: span.clone(),
+            }
+            .into()),
+        }
+    }
+
+    fn resolve_field_method_type(&self, field_method: &FieldMethod, span: &Span) -> Result<TypeId> {
+        match field_method {
+            FieldMethod::Type(rf, index) => {
+                let object_ref = self.resolve_object_reference_type(*rf, span)?;
+                let HirType::Struct { fields } = self.get_type_from_ref(object_ref).clone() else {
+                    unreachable!("object layouts should always resolve to structs");
+                };
+                Ok(fields[*index])
+            }
+            FieldMethod::Variable(variable_id, field_name) => {
+                let variable_ty = *self
+                    .types_module
+                    .get_variable(variable_id)
+                    .expect("variable type should exist before field access lowering");
+                let object_ref = self.resolve_object_reference_type(variable_ty, span)?;
+                let Some(layout) = self.declarations_module.retrieve_object_body(object_ref) else {
+                    unreachable!("object reference should carry a layout");
+                };
+                let HirType::Struct { fields } = self.get_type_from_ref(object_ref).clone() else {
+                    unreachable!("object layouts should always resolve to structs");
+                };
+                let Some(index) = layout.iter().position(|field| field == field_name) else {
+                    return Err(HIRError {
+                        kind: HIRErrorKind::PropertyNotRecognized {
+                            prop_names: vec![self.symbols_module[*field_name].to_string()],
+                        },
+                        span: span.clone(),
+                    }
+                    .into());
+                };
+                Ok(fields[index])
+            }
+            FieldMethod::Tuple(rf, index) => self.resolve_tuple_access_type(*rf, *index, span),
+        }
+    }
+
+    fn resolve_object_reference_type(&self, ty: TypeId, span: &Span) -> Result<TypeId> {
+        // Chained accesses can arrive here through variables, aliases, or
+        // previous field accesses, so normalize them into the object reference
+        // that actually owns the named layout.
+        let current_ty = self.types_module.get_type(&ty).clone();
+        match current_ty {
+            HirType::VarReference(variable_id) => {
+                let variable_ty = *self
+                    .types_module
+                    .get_variable(&variable_id)
+                    .expect("variable type should exist before field access lowering");
+                self.resolve_object_reference_type(variable_ty, span)
+            }
+            HirType::Field(field_method) => {
+                let field_ty = self.resolve_field_method_type(&field_method, span)?;
+                self.resolve_object_reference_type(field_ty, span)
+            }
+            HirType::Reference { rf, .. } => {
+                if self.declarations_module.retrieve_object_body(ty).is_some() {
+                    Ok(ty)
+                } else {
+                    self.resolve_object_reference_type(rf, span)
+                }
+            }
+            other => Err(HIRError {
+                kind: HIRErrorKind::InvalidFieldAccessTarget { ty: other },
+                span: span.clone(),
+            }
+            .into()),
+        }
+    }
+
     /// Resolves the provided `expr` trying to infer its type, if not able, keeps as infer, and on later phases fallsback to the default value.
     /// Ty only serves to tell the type of the expression if it's needed to infer and check if it doesnt correspond
     pub fn resolve_expr(
@@ -130,8 +233,23 @@ impl SlynxHir {
                     span: expr.span,
                 })
             }
-            ASTExpressionKind::TupleAccess { .. } => {
-                todo!("sla");
+            ASTExpressionKind::TupleAccess { tuple, index } => {
+                let tuple = self.resolve_expr(*tuple, None)?;
+                let tuple_field_ty = self.types_module.insert_unnamed_type(HirType::Field(
+                    // Keep tuple accesses distinct from object fields so later
+                    // phases can reject numeric access on non-tuples.
+                    FieldMethod::Tuple(tuple.ty, index),
+                ));
+
+                Ok(HirExpression {
+                    id: ExpressionId::new(),
+                    ty: tuple_field_ty,
+                    kind: HirExpressionKind::FieldAccess {
+                        expr: Box::new(tuple),
+                        field_index: index,
+                    },
+                    span: expr.span,
+                })
             }
 
             ASTExpressionKind::If {
@@ -378,7 +496,43 @@ impl SlynxHir {
                             span: expr.span,
                         })
                     }
-                    u => unreachable!("{u:?}"),
+                    HirType::Field(_) => {
+                        let object_ref = self.resolve_object_reference_type(*ty, &expr.span)?;
+                        let Some(layout) =
+                            self.declarations_module.retrieve_object_body(object_ref)
+                        else {
+                            unreachable!("object reference should carry a layout");
+                        };
+                        if let Some(index) = layout.iter().position(|struct_field| {
+                            &self.symbols_module.intern(&field) == struct_field
+                        }) {
+                            let field_ty = self.types_module.insert_unnamed_type(HirType::Field(
+                                FieldMethod::Type(object_ref, index),
+                            ));
+                            Ok(HirExpression {
+                                id: ExpressionId::new(),
+                                ty: field_ty,
+                                kind: HirExpressionKind::FieldAccess {
+                                    expr: Box::new(parent),
+                                    field_index: index,
+                                },
+                                span: expr.span,
+                            })
+                        } else {
+                            Err(HIRError {
+                                kind: HIRErrorKind::PropertyNotRecognized {
+                                    prop_names: vec![field],
+                                },
+                                span: expr.span,
+                            }
+                            .into())
+                        }
+                    }
+                    u => Err(HIRError {
+                        kind: HIRErrorKind::InvalidFieldAccessTarget { ty: u.clone() },
+                        span: expr.span,
+                    }
+                    .into()),
                 }
             }
         }

--- a/frontend/src/hir/implementation/statements.rs
+++ b/frontend/src/hir/implementation/statements.rs
@@ -12,6 +12,9 @@ impl SlynxHir {
             ASTExpressionKind::FieldAccess { parent, .. } => {
                 self.check_existance(parent)?;
             }
+            ASTExpressionKind::TupleAccess { tuple, .. } => {
+                self.check_existance(tuple)?;
+            }
             ASTExpressionKind::Identifier(name) => {
                 self.get_variable(name, &expr.span)?;
             }

--- a/frontend/src/hir/types/tys.rs
+++ b/frontend/src/hir/types/tys.rs
@@ -22,6 +22,9 @@ pub enum FieldMethod {
     ///This is the same of the `type` variant, but since the provided `id` is the id of some variable whose type may be a Reference to a type, or
     ///a reference to another variable that references a type, we must store the field being accessed and check it on the type checker
     Variable(VariableId, SymbolPointer),
+    ///Tuple accesses carry their numeric index from the parser so later phases
+    /// can validate bounds without confusing them with named object fields.
+    Tuple(TypeId, usize),
 }
 
 #[derive(Debug, Clone)]

--- a/frontend/src/lexer/mod.rs
+++ b/frontend/src/lexer/mod.rs
@@ -196,22 +196,53 @@ impl Lexer {
                     let mut last_is_underscore = false;
                     let mut last_is_dot = false;
                     let mut should_err = false;
-                    while let Some(c) = chars.get(idx)
-                        && (c.is_ascii_digit() || *c == '.' || *c == '_')
-                    {
-                        if *c == '.' {
-                            float_value = true;
-                        }
-                        if (*c == '.' && last_is_dot) || (*c == '_' && last_is_underscore) {
-                            should_err = true;
+                    while let Some(c) = chars.get(idx) {
+                        if c.is_ascii_digit() {
+                            last_is_dot = false;
+                            last_is_underscore = false;
+                            buffer.push(*c);
+                            idx += 1;
+                            continue;
                         }
 
-                        last_is_dot = *c == '.';
-                        last_is_underscore = *c == '_';
-                        buffer.push(*c);
-                        idx += 1;
+                        if *c == '_' {
+                            if last_is_underscore || last_is_dot {
+                                should_err = true;
+                            }
+                            last_is_dot = false;
+                            last_is_underscore = true;
+                            buffer.push(*c);
+                            idx += 1;
+                            continue;
+                        }
+
+                        if *c == '.' {
+                            let next = chars.get(idx + 1);
+                            if !float_value && matches!(next, Some(next) if next.is_ascii_digit()) {
+                                // Only keep '.' inside a number when it actually starts
+                                // the fractional part of a float literal.
+                                float_value = true;
+                                if last_is_underscore {
+                                    should_err = true;
+                                }
+                                last_is_dot = true;
+                                last_is_underscore = false;
+                                buffer.push(*c);
+                                idx += 1;
+                                continue;
+                            }
+
+                            if matches!(next, Some('.') | Some('_')) {
+                                should_err = true;
+                                buffer.push(*c);
+                                idx += 1;
+                            }
+                            break;
+                        }
+
+                        break;
                     }
-                    if should_err || buffer.ends_with("_") {
+                    if should_err || buffer.ends_with('_') || buffer.ends_with('.') {
                         return Err(LexerError::MalformedNumber {
                             number: buffer,
                             init: start,
@@ -327,5 +358,50 @@ impl Lexer {
             stream: out,
             new_lines: lines,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Lexer, error::LexerError, tokens::TokenKind};
+
+    #[test]
+    fn lexes_tuple_access_index_as_a_standalone_integer() {
+        let tokens = Lexer::tokenize("pair.0.age")
+            .expect("tuple access should keep the numeric index separate from dots");
+        let kinds = tokens
+            .stream
+            .into_iter()
+            .map(|token| token.kind)
+            .collect::<Vec<_>>();
+
+        assert!(matches!(kinds[0], TokenKind::Identifier(ref name) if name == "pair"));
+        assert!(matches!(kinds[1], TokenKind::Dot));
+        assert!(matches!(kinds[2], TokenKind::Int(0)));
+        assert!(matches!(kinds[3], TokenKind::Dot));
+        assert!(matches!(kinds[4], TokenKind::Identifier(ref name) if name == "age"));
+    }
+
+    #[test]
+    fn rejects_double_dot_number_patterns() {
+        let err = Lexer::tokenize("4..0").expect_err("double-dot numerics should stay malformed");
+
+        assert!(
+            matches!(err, LexerError::MalformedNumber { .. }),
+            "expected malformed number, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_numeric_separators_adjacent_to_decimal_points() {
+        for source in ["1._0", "1_.0"] {
+            let err = Lexer::tokenize(source)
+                .expect_err("numeric separators next to decimal points should be malformed");
+
+            assert!(
+                matches!(err, LexerError::MalformedNumber { .. }),
+                "expected malformed number for {source}, got {err:?}"
+            );
+        }
     }
 }

--- a/frontend/src/parser/expr.rs
+++ b/frontend/src/parser/expr.rs
@@ -276,12 +276,21 @@ impl Parser {
                 )),
             }?
         };
-        if let TokenKind::Dot = self.peek()?.kind {
+
+        self.parse_postfix_chain(expr)
+    }
+
+    fn parse_postfix_chain(&mut self, mut expr: ASTExpression) -> Result<ASTExpression> {
+        // Keep postfix parsing iterative so tuple access and chained field access
+        // share the same code path.
+        while let Ok(token) = self.peek()
+            && token.kind == TokenKind::Dot
+        {
             self.eat()?;
-            self.parse_dot_postfix(expr)
-        } else {
-            Ok(expr)
+            expr = self.parse_dot_postfix(expr)?;
         }
+
+        Ok(expr)
     }
 
     /// Parses multiplicative expressions, which consist of primary expressions combined with multiplication '*' or division '/' operators. It handles operator precedence by first parsing the left-hand side (LHS) as a primary expression, and then repeatedly checking for multiplicative operators and parsing the right-hand side (RHS) as another primary expression until no more multiplicative operators are found.
@@ -445,6 +454,18 @@ impl Parser {
                 kind: ASTExpressionKind::FieldAccess {
                     parent: Box::new(prefix),
                     field,
+                },
+            }),
+            TokenKind::Int(index) if index >= 0 => Ok(ASTExpression {
+                span: Span {
+                    start: prefix.span.start,
+                    end: current.span.end,
+                },
+                // Tuple access is represented explicitly in the AST so later
+                // phases can decide how to normalize it.
+                kind: ASTExpressionKind::TupleAccess {
+                    tuple: Box::new(prefix),
+                    index: index as usize,
                 },
             }),
             _ => Err(ParseError::UnexpectedToken(current, "A field access".to_string()).into()),

--- a/frontend/tests/hir.rs
+++ b/frontend/tests/hir.rs
@@ -1,5 +1,8 @@
 use common::{ASTExpression, ASTExpressionKind, Span};
-use frontend::hir::{SlynxHir, types::HirType};
+use frontend::hir::{
+    SlynxHir,
+    types::{FieldMethod, HirType},
+};
 
 fn generate_hir(kind: ASTExpressionKind) -> ASTExpression {
     let span = Span { start: 0, end: 0 };
@@ -27,5 +30,41 @@ fn test_hir_tuple() {
             assert_eq!(fields.len(), 2);
         }
         _ => panic!("expected HirType::Tuple"),
+    }
+}
+
+#[test]
+fn test_hir_tuple_access_lowers_to_field_access() {
+    let tuple_ast = generate_hir(ASTExpressionKind::TupleAccess {
+        tuple: Box::new(generate_hir(ASTExpressionKind::Tuple(vec![
+            generate_hir(ASTExpressionKind::IntLiteral(10)),
+            generate_hir(ASTExpressionKind::StringLiteral("ok".to_string())),
+        ]))),
+        index: 1,
+    });
+    let mut hir = SlynxHir::new();
+    let result = hir.resolve_expr(tuple_ast, None);
+    assert!(result.is_ok(), "err in tuple access hir: {:?}", result);
+    let tuple_access = result.unwrap();
+
+    match tuple_access.kind {
+        frontend::hir::definitions::HirExpressionKind::FieldAccess {
+            ref expr,
+            field_index,
+        } => {
+            assert_eq!(field_index, 1);
+            assert!(matches!(
+                expr.kind,
+                frontend::hir::definitions::HirExpressionKind::Tuple(_)
+            ));
+        }
+        _ => panic!("expected HirExpressionKind::FieldAccess"),
+    }
+
+    match hir.types_module.get_type(&tuple_access.ty) {
+        HirType::Field(FieldMethod::Tuple(_, index)) => {
+            assert_eq!(*index, 1);
+        }
+        _ => panic!("expected tuple access to keep tuple field metadata"),
     }
 }

--- a/frontend/tests/parser.rs
+++ b/frontend/tests/parser.rs
@@ -51,6 +51,66 @@ func main(): int {
     assert!(ty.is_none());
     assert!(matches!(rhs.kind, ASTExpressionKind::Tuple(_)));
 }
+
+#[test]
+fn parses_tuple_access_from_tuple_literal() {
+    let declarations = parse_source(
+        r#"
+func main(): int {
+    let value = (1, 2).0;
+    value
+}
+"#,
+    );
+
+    let body = function_body(&declarations, "main");
+    assert_eq!(body.len(), 2);
+
+    let ASTStatementKind::Var { rhs, .. } = &body[0].kind else {
+        panic!("expected let statement");
+    };
+
+    let ASTExpressionKind::TupleAccess { tuple, index } = &rhs.kind else {
+        panic!("expected tuple access");
+    };
+
+    assert_eq!(*index, 0);
+    assert!(matches!(tuple.kind, ASTExpressionKind::Tuple(_)));
+}
+
+#[test]
+fn parses_chained_tuple_and_field_access() {
+    let declarations = parse_source(
+        r#"
+object Person {
+    age: int,
+}
+
+func main(): int {
+    let value = (Person(age: 22), "ok");
+    value.0.age
+}
+"#,
+    );
+
+    let body = function_body(&declarations, "main");
+    assert_eq!(body.len(), 2);
+
+    let ASTStatementKind::Expression(expr) = &body[1].kind else {
+        panic!("expected trailing expression");
+    };
+
+    let ASTExpressionKind::FieldAccess { parent, field } = &expr.kind else {
+        panic!("expected outer field access");
+    };
+    assert_eq!(field, "age");
+
+    let ASTExpressionKind::TupleAccess { tuple, index } = &parent.kind else {
+        panic!("expected tuple access before named field access");
+    };
+    assert_eq!(*index, 0);
+    assert!(matches!(&tuple.kind, ASTExpressionKind::Identifier(name) if name == "value"));
+}
 #[test]
 fn parses_function_body_statement_shapes() {
     let declarations = parse_source(

--- a/slynx/tuple_access.slynx
+++ b/slynx/tuple_access.slynx
@@ -1,0 +1,8 @@
+object Person {
+    age: int,
+}
+
+func main(): int {
+    let pair = (Person(age: 22), "ok");
+    pair.0.age
+}

--- a/tests/tuples.rs
+++ b/tests/tuples.rs
@@ -11,3 +11,18 @@ fn test_tuple() {
         Some("sir")
     );
 }
+
+#[test]
+fn test_tuple_access() {
+    let context =
+        slynx::SlynxContext::new(Arc::new(PathBuf::from("slynx/tuple_access.slynx"))).unwrap();
+    let output = context.compile().unwrap();
+
+    assert_eq!(
+        output
+            .output_path()
+            .extension()
+            .and_then(|ext| ext.to_str()),
+        Some("sir")
+    );
+}


### PR DESCRIPTION
## Summary
- add tuple access parsing for numeric postfixes like `pair.0`
- keep tuple access explicit through HIR/type-checking while still lowering through the existing field-access pipeline
- allow chained postfix parsing such as `pair.0.age`
- refine numeric lexing so tuple access stops treating `0.` as a float prefix and keep malformed number checks for `4..0` and separator edge cases
- add regression coverage across lexer, parser, HIR, checker, and integration tests

## Why This Matters
- tuple types and tuple literals already exist, so tuple access was the next grounded gap in the surface
- chaining postfixes through the parser/HIR makes the feature usable in real code instead of only in isolated expressions
- the lexer adjustment keeps tuple access syntax readable without regressing the numeric separator work

## Scope
- parser postfix handling
- HIR lowering and error surfacing for tuple access
- checker support for tuple index validation
- lexer hardening for float-vs-postfix boundaries
- regression tests and a compileable sample file

## Validation
- cargo fmt --all
- cargo test -p frontend --lib --test parser --test hir
- cargo test --test tuples
- cargo test --no-run
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check
