### PR TITLE
feat: add number-systems

### DIFF
--- a/frontend/src/lexer/mod.rs
+++ b/frontend/src/lexer/mod.rs
@@ -196,6 +196,52 @@ impl Lexer {
                     let mut last_is_underscore = false;
                     let mut last_is_dot = false;
                     let mut should_err = false;
+                    let mut hex_value = false;
+                    let mut binary_value = false;
+                    let mut radix = 0;
+                    let mut octal_value = false;
+
+
+                    if let Some('0') = chars.get(idx) {
+                        match chars.get(idx + 1) {
+                            Some('x') => {
+                                radix += 16;
+                                idx += 2;
+                                hex_value = true;
+                                while let Some(c) = chars.get(idx)
+                                    && (c.is_ascii_hexdigit())
+                                {
+                                    buffer.push(*c);
+                                    idx += 1;
+                                }
+                            }
+                            Some('b') => {
+                                binary_value = true;
+                                radix += 2;
+                                idx += 2;
+                                while let Some(c) = chars.get(idx)
+                                    && (*c == '0' || *c == '1')
+                                {
+                                    buffer.push(*c);
+                                    idx += 1;
+                                }
+                            }
+                            Some('o') => {
+                                octal_value = true;
+                                radix += 8;
+                                idx += 2;
+                                while let Some(c) = chars.get(idx)
+                                    && (c.is_digit(radix))
+                                {
+                                    buffer.push(*c);
+                                    idx += 1;
+                                }
+                            }
+                            _ => (),
+                        }
+                    }
+                    
+                    if !hex_value && !binary_value && !octal_value {
                     while let Some(c) = chars.get(idx) {
                         if c.is_ascii_digit() {
                             last_is_dot = false;
@@ -242,6 +288,7 @@ impl Lexer {
 
                         break;
                     }
+                }
                     if should_err || buffer.ends_with('_') || buffer.ends_with('.') {
                         return Err(LexerError::MalformedNumber {
                             number: buffer,
@@ -249,9 +296,24 @@ impl Lexer {
                             end: idx,
                         });
                     }
+
                     idx -= 1;
                     let buffer = buffer.replace('_', "");
-                    if float_value {
+                    if hex_value || binary_value || octal_value {
+                        let decimal_value = i32::from_str_radix(&buffer, radix);
+
+                        match decimal_value {
+                            Ok(value) => Token::int(value, start, idx),
+                            Err(_) => {
+                                return Err(LexerError::MalformedNumber {
+                                    number: buffer,
+                                    init: start,
+                                    end: idx,
+                                });
+                            }
+                        }
+                    }
+                    else if float_value {
                         match buffer.parse::<f32>() {
                             Ok(value) => Token::float(value, start, idx),
                             Err(_) => {

--- a/slynx/number_systems.slynx
+++ b/slynx/number_systems.slynx
@@ -1,0 +1,5 @@
+func main() : void{
+   let x = 0x2A + 0x2b;
+   let y = 0b0110 + 0b1010;
+   let z = 0o071 + 0o172;
+}

--- a/tests/number_systems.rs
+++ b/tests/number_systems.rs
@@ -1,0 +1,16 @@
+use std::{path::PathBuf, sync::Arc};
+
+#[test]
+fn test_number_systems() {
+    let context =
+        slynx::SlynxContext::new(Arc::new(PathBuf::from("slynx/number_systems.slynx"))).unwrap();
+    let output = context.compile().unwrap();
+
+    assert_eq!(
+        output
+            .output_path()
+            .extension()
+            .and_then(|ext| ext.to_str()),
+        Some("sir")
+    );
+}


### PR DESCRIPTION
## Summary
This PR implements support for multiple number systems in the Slynx Lexer. It adds recognition for Hexadecimal (0x), Binary (0b), and Octal (0o) literals.

## Scope

- **what changed**

1. Updated the Lexer logic to detect 0x, 0b, and 0o prefixes.
2. Fixed a bug where the Lexer would "fall through" from hex detection into decimal/float logic.

- **what did not change**

1. The core logic for standard decimal integers and floating-point numbers remains intact.
2. Existing token structures were preserved; only their generation was updated.

## Validation

If you wanna test, try: 
```bash 
cargo test
```


## Checklist

-  [x] My change is focused and reviewable
-  [x] I performed a self-review
-  [ ] I added comments only where they help explain non-obvious logic
- [x] I added or updated tests when applicable
- [x] I ran the validation listed above
- [x] I used the existing issue/PR templates where applicable

