### PR TITLE
Fix/parser empty test

### DIFF
--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -1,2 +1,26 @@
+use common::ast::ASTDeclarationKind;
+use frontend::{lexer::Lexer, parser::Parser};
+
 #[test]
-fn test_parser() {}
+fn test_parser_parses_main_from_fixture() {
+	let source = std::fs::read_to_string("slynx/component.slynx")
+		.expect("fixture slynx/component.slynx should exist");
+	let tokens = Lexer::tokenize(&source).expect("fixture should tokenize");
+	let declarations = Parser::new(tokens)
+		.parse_declarations()
+		.expect("fixture should parse");
+
+	assert!(
+		!declarations.is_empty(),
+		"parsed declarations should not be empty"
+	);
+
+	let has_main = declarations.iter().any(|decl| {
+		matches!(
+			&decl.kind,
+			ASTDeclarationKind::FuncDeclaration { name, .. } if name.identifier == "main"
+		)
+	});
+
+	assert!(has_main, "expected fixture to contain func main");
+}

--- a/tests/parser.rs
+++ b/tests/parser.rs
@@ -3,24 +3,24 @@ use frontend::{lexer::Lexer, parser::Parser};
 
 #[test]
 fn test_parser_parses_main_from_fixture() {
-	let source = std::fs::read_to_string("slynx/component.slynx")
-		.expect("fixture slynx/component.slynx should exist");
-	let tokens = Lexer::tokenize(&source).expect("fixture should tokenize");
-	let declarations = Parser::new(tokens)
-		.parse_declarations()
-		.expect("fixture should parse");
+    let source = std::fs::read_to_string("slynx/component.slynx")
+        .expect("fixture slynx/component.slynx should exist");
+    let tokens = Lexer::tokenize(&source).expect("fixture should tokenize");
+    let declarations = Parser::new(tokens)
+        .parse_declarations()
+        .expect("fixture should parse");
 
-	assert!(
-		!declarations.is_empty(),
-		"parsed declarations should not be empty"
-	);
+    assert!(
+        !declarations.is_empty(),
+        "parsed declarations should not be empty"
+    );
 
-	let has_main = declarations.iter().any(|decl| {
-		matches!(
-			&decl.kind,
-			ASTDeclarationKind::FuncDeclaration { name, .. } if name.identifier == "main"
-		)
-	});
+    let has_main = declarations.iter().any(|decl| {
+        matches!(
+            &decl.kind,
+            ASTDeclarationKind::FuncDeclaration { name, .. } if name.identifier == "main"
+        )
+    });
 
-	assert!(has_main, "expected fixture to contain func main");
+    assert!(has_main, "expected fixture to contain func main");
 }


### PR DESCRIPTION
## Summary

Replaces the empty parser test with a real integration test to prevent silent regressions in this area. The new test reads a language fixture, runs tokenization and parsing, and validates that a main function exists in the parsed declarations.

## Scope

- **what changed**
  - Replaced the empty test with a real parser integration test in `parser.rs`
  - Added assertions for non-empty declarations and presence of main
  - Kept indentation/style aligned with repository formatting
- **what did not change**
  - No production compiler behavior was changed
  - No parser implementation files were modified
  - No documentation files were modified
- **any follow-up left for later**
  - Run full Rust validation locally once Cargo/Rust is available in the environment

## Validation

Manual checks performed:
- Confirmed diff scope is limited to `parser.rs`
- Confirmed no editor diagnostics in `parser.rs`
- Confirmed fixture content in `component.slynx` includes main

Not executed in this environment (Cargo/Rust unavailable):
```bash
cargo test
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings

## Documentation Impact

- [x] No documentation changes were needed
- [ ] I updated the relevant documentation

## Checklist

- [x] My change is focused and reviewable
- [x] I performed a self-review
- [x] I added comments only where they help explain non-obvious logic
- [x] I added or updated tests when applicable
- [ ] I ran the validation listed above
- [x] I used the existing issue/PR templates where applicable

## Related Issues

No linked issue.