### PR TITLE
fix: add type void in formatter

### DIFF
--- a/middleend/src/ir/visualize/formatter.rs
+++ b/middleend/src/ir/visualize/formatter.rs
@@ -237,6 +237,7 @@ impl<'a> Formatter<'a> {
                 }
             }
             Value::StructLiteral(..) => format!("%lit{}", ptr.ptr()),
+            Value::Void => "void".to_string(),
         }
     }
 


### PR DESCRIPTION
## Summary

Fixed a CI failure caused by missing handling of the `Void` type in the IR formatter.
The change ensures that `Value::Void` is properly converted to a string representation, preventing formatting errors during CI checks.

## Scope

* **What changed**

  * Added explicit handling for `Value::Void` in `formatter.rs`
  * Ensured the formatter returns `"void"` when encountering this variant

* **What did not change**

  * No changes to IR structure or semantics
  * No modifications to parsing, type system, or code generation

* **Follow-up**

  * Consider auditing other `Value` variants to ensure full formatter coverage
  * Add tests for edge cases involving `Void` values

## Validation

The following checks were executed to validate the fix:

```bash
cargo check
cargo test
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
```

Additionally:

* Verified that CI passes successfully after the fix
* Confirmed no regressions in existing functionality

## Documentation Impact

* [x] No documentation changes were needed
* [ ] I updated the relevant documentation

## Checklist

* [x] My change is focused and reviewable
* [x] I performed a self-review
* [x] I added comments only where they help explain non-obvious logic
* [ ] I added or updated tests when applicable
* [x] I ran the validation listed above
* [x] I used the existing issue/PR templates where applicable

## Related Issues

