### PR TITLE
Feat/improve ir visualizer

### DIFF
--- a/middleend/src/ir/contexts.rs
+++ b/middleend/src/ir/contexts.rs
@@ -234,31 +234,35 @@ impl SlynxIR {
                     true,
                 );
 
-                // Reset instruction pointers for then/else/end labels to start AFTER the Cbr.
-                // All three labels were created before the Cbr was inserted, so they share the
-                // same ptr offset and would incorrectly "see" the Cbr as their own instruction.
                 {
                     let next = self.get_next_mapeable_instruction_ptr();
                     let mut fresh = next.with_length::<0>();
                     fresh.set_length(0);
-                    self.get_label_mut(then_label).set_instructions_pointer(fresh);
-                    self.get_label_mut(else_label).set_instructions_pointer(fresh);
-                    self.get_label_mut(end_label).set_instructions_pointer(fresh);
+                    self.get_label_mut(then_label)
+                        .set_instructions_pointer(fresh);
                 }
 
                 temp.set_current_label(then_label);
                 self.lower_if_branch(then_branch, end_label, temp)?;
 
-                temp.set_current_label(else_label);
-                let else_branch = else_branch.as_deref().unwrap_or(&[]);
-                self.lower_if_branch(else_branch, end_label, temp)?;
-
-                // Update end_label's instruction pointer to start after the branches' Br instructions.
                 {
                     let next = self.get_next_mapeable_instruction_ptr();
                     let mut fresh = next.with_length::<0>();
                     fresh.set_length(0);
-                    self.get_label_mut(end_label).set_instructions_pointer(fresh);
+                    self.get_label_mut(else_label)
+                        .set_instructions_pointer(fresh);
+                }
+
+                temp.set_current_label(else_label);
+                let else_branch = else_branch.as_deref().unwrap_or(&[]);
+                self.lower_if_branch(else_branch, end_label, temp)?;
+
+                {
+                    let next = self.get_next_mapeable_instruction_ptr();
+                    let mut fresh = next.with_length::<0>();
+                    fresh.set_length(0);
+                    self.get_label_mut(end_label)
+                        .set_instructions_pointer(fresh);
                 }
 
                 temp.set_current_label(end_label);

--- a/middleend/src/ir/contexts.rs
+++ b/middleend/src/ir/contexts.rs
@@ -234,12 +234,32 @@ impl SlynxIR {
                     true,
                 );
 
+                // Reset instruction pointers for then/else/end labels to start AFTER the Cbr.
+                // All three labels were created before the Cbr was inserted, so they share the
+                // same ptr offset and would incorrectly "see" the Cbr as their own instruction.
+                {
+                    let next = self.get_next_mapeable_instruction_ptr();
+                    let mut fresh = next.with_length::<0>();
+                    fresh.set_length(0);
+                    self.get_label_mut(then_label).set_instructions_pointer(fresh);
+                    self.get_label_mut(else_label).set_instructions_pointer(fresh);
+                    self.get_label_mut(end_label).set_instructions_pointer(fresh);
+                }
+
                 temp.set_current_label(then_label);
                 self.lower_if_branch(then_branch, end_label, temp)?;
 
                 temp.set_current_label(else_label);
                 let else_branch = else_branch.as_deref().unwrap_or(&[]);
                 self.lower_if_branch(else_branch, end_label, temp)?;
+
+                // Update end_label's instruction pointer to start after the branches' Br instructions.
+                {
+                    let next = self.get_next_mapeable_instruction_ptr();
+                    let mut fresh = next.with_length::<0>();
+                    fresh.set_length(0);
+                    self.get_label_mut(end_label).set_instructions_pointer(fresh);
+                }
 
                 temp.set_current_label(end_label);
                 let end_label = self.get_label(end_label);

--- a/middleend/src/ir/mod.rs
+++ b/middleend/src/ir/mod.rs
@@ -76,7 +76,7 @@ impl SlynxIR {
                 HirDeclarationKind::Object => {
                     let out = self
                         .types
-                        .create_empty_struct(tys.get_type_name(&declaration.ty).unwrap().clone());
+                        .create_empty_struct(*tys.get_type_name(&declaration.ty).unwrap());
                     temp.define_type(declaration.ty, out);
                     // Also map the inner unnamed Struct TypeId (the `rf` of the Reference)
                     if let HirType::Reference { rf, .. } = tys.get_type(&declaration.ty) {
@@ -144,18 +144,7 @@ impl SlynxIR {
     /// This uses the helpers defined in the `visualize` module to format labels and
     /// instructions in the human-readable SIR form described in `middleend/README.md`.
     pub fn format_sir(&self) -> String {
-        let fmt = visualize::Formatter::new(
-            &self.labels,
-            &self.contexts,
-            &self.components,
-            &self.values,
-            &self.operands,
-            &self.types,
-            &self.strings,
-            &self.specialized,
-            &self.instruction_pointers,
-            &self.instructions,
-        );
+        let fmt = visualize::Formatter::new(self, &self.strings);
         let mut out = fmt.format_types();
         out.push_str(&fmt.format_contexts());
         out

--- a/middleend/src/ir/mod.rs
+++ b/middleend/src/ir/mod.rs
@@ -151,7 +151,8 @@ impl SlynxIR {
             &self.types,
             &self.strings,
         );
-
-        fmt.format_labels(&self.instructions)
+        let mut out = fmt.format_types();
+        out.push_str(&fmt.format_labels(&self.instructions));
+        out
     }
 }

--- a/middleend/src/ir/mod.rs
+++ b/middleend/src/ir/mod.rs
@@ -74,7 +74,9 @@ impl SlynxIR {
         for declaration in &hir {
             match &declaration.kind {
                 HirDeclarationKind::Object => {
-                    let out = self.types.create_empty_struct();
+                    let out = self
+                        .types
+                        .create_empty_struct(tys.get_type_name(&declaration.ty).unwrap().clone());
                     temp.define_type(declaration.ty, out);
                     // Also map the inner unnamed Struct TypeId (the `rf` of the Reference)
                     if let HirType::Reference { rf, .. } = tys.get_type(&declaration.ty) {

--- a/middleend/src/ir/mod.rs
+++ b/middleend/src/ir/mod.rs
@@ -147,13 +147,17 @@ impl SlynxIR {
         let fmt = visualize::Formatter::new(
             &self.labels,
             &self.contexts,
+            &self.components,
             &self.values,
             &self.operands,
             &self.types,
             &self.strings,
+            &self.specialized,
+            &self.instruction_pointers,
+            &self.instructions,
         );
         let mut out = fmt.format_types();
-        out.push_str(&fmt.format_contexts(&self.instructions));
+        out.push_str(&fmt.format_contexts());
         out
     }
 }

--- a/middleend/src/ir/mod.rs
+++ b/middleend/src/ir/mod.rs
@@ -146,13 +146,14 @@ impl SlynxIR {
     pub fn format_sir(&self) -> String {
         let fmt = visualize::Formatter::new(
             &self.labels,
+            &self.contexts,
             &self.values,
             &self.operands,
             &self.types,
             &self.strings,
         );
         let mut out = fmt.format_types();
-        out.push_str(&fmt.format_labels(&self.instructions));
+        out.push_str(&fmt.format_contexts(&self.instructions));
         out
     }
 }

--- a/middleend/src/ir/visualize/formatter.rs
+++ b/middleend/src/ir/visualize/formatter.rs
@@ -5,10 +5,11 @@ use common::SymbolsModule;
 use crate::{
     Component, Context, IRComponentId, IRPointer, IRSpecializedComponent,
     IRSpecializedComponentType, IRStructId, IRType, IRTypes, Instruction, InstructionType, Label,
-    Operand, Slot, Value,
+    Operand, SlynxIR, Value,
 };
 
 pub struct Formatter<'a> {
+    pub ir: &'a SlynxIR,
     pub labels: &'a [Label],
     pub contexts: &'a [Context],
     pub components: &'a [Component],
@@ -24,19 +25,18 @@ pub struct Formatter<'a> {
 }
 
 impl<'a> Formatter<'a> {
-    pub fn new(
-        labels: &'a [Label],
-        contexts: &'a [Context],
-        components: &'a [Component],
-        values: &'a [Value],
-        operands: &'a [Operand],
-        types: &'a IRTypes,
-        symbols: &'a SymbolsModule,
-        specialized: &'a [IRSpecializedComponent],
-        instruction_pointers: &'a [IRPointer<Instruction>],
-        instructions: &'a [Instruction],
-    ) -> Self {
+    pub fn new(ir: &'a SlynxIR, symbols: &'a SymbolsModule) -> Self {
+        let labels = &ir.labels;
+        let contexts = &ir.contexts;
+        let components = &ir.components;
+        let values = &ir.values;
+        let operands = &ir.operands;
+        let types = &ir.types;
+        let specialized = &ir.specialized;
+        let instruction_pointers = &ir.instruction_pointers;
+        let instructions = &ir.instructions;
         Self {
+            ir,
             contexts,
             components,
             labels,
@@ -53,7 +53,11 @@ impl<'a> Formatter<'a> {
     }
 
     fn with_label_offset(&self, offset: usize) -> Formatter<'a> {
-        Formatter { label_offset: offset, inline_set: HashSet::new(), ..*self }
+        Formatter {
+            label_offset: offset,
+            inline_set: HashSet::new(),
+            ..*self
+        }
     }
 
     // --- type formatting ---
@@ -80,7 +84,9 @@ impl<'a> Formatter<'a> {
             IRType::Struct(t) => self.fmt_struct_type(t),
             IRType::Component(c) => self.fmt_component_type(c),
             IRType::Specialized(IRSpecializedComponentType::Div) => "specialized(div)".to_string(),
-            IRType::Specialized(IRSpecializedComponentType::Text) => "specialized(text)".to_string(),
+            IRType::Specialized(IRSpecializedComponentType::Text) => {
+                "specialized(text)".to_string()
+            }
         }
     }
 
@@ -119,7 +125,11 @@ impl<'a> Formatter<'a> {
                 .map(|f| self.fmt_type(&self.types.get_type(*f)))
                 .collect::<Vec<_>>()
                 .join(",");
-            out.push_str(&format!("struct %{}{{{}}};\n", self.symbols.get_name(name), fields));
+            out.push_str(&format!(
+                "struct %{}{{{}}};\n",
+                self.symbols.get_name(name),
+                fields
+            ));
         }
         out
     }
@@ -139,7 +149,11 @@ impl<'a> Formatter<'a> {
         let IRType::Function(fty) = self.types.get_type(ctx.ty()) else {
             unreachable!("Type of context should be function");
         };
-        let ret_ty = self.fmt_type(&self.types.get_type(self.types.get_function_type(fty).get_return_type()));
+        let ret_ty = self.fmt_type(
+            &self
+                .types
+                .get_type(self.types.get_function_type(fty).get_return_type()),
+        );
         let mut out = format!("{ret_ty} {}(){{\n", self.symbols.get_name(ctx.name()));
 
         let labels_ptr = ctx.labels_ptr();
@@ -163,10 +177,19 @@ impl<'a> Formatter<'a> {
             .collect::<Vec<_>>()
             .join(", ");
 
-        let mut out = format!("component %{}({}) {{\n", self.symbols.get_name(comp_ty.name()), params);
+        let mut out = format!(
+            "component %{}({}) {{\n",
+            self.symbols.get_name(comp_ty.name()),
+            params
+        );
 
         for (i, field_ty) in comp_ty.fields().iter().enumerate() {
-            out.push_str(&format!("  %field{}: {} = p{};\n", i, self.fmt_type(&self.types.get_type(*field_ty)), i));
+            out.push_str(&format!(
+                "  %field{}: {} = p{};\n",
+                i,
+                self.fmt_type(&self.types.get_type(*field_ty)),
+                i
+            ));
         }
 
         let values_range = component.values();
@@ -206,7 +229,10 @@ impl<'a> Formatter<'a> {
         };
 
         let inline_set = self.build_inline_set(label);
-        let fmt = Formatter { inline_set, ..*self };
+        let fmt = Formatter {
+            inline_set,
+            ..*self
+        };
 
         let iptr = label.instructions();
         let mut emitted = BTreeSet::new();
@@ -219,7 +245,11 @@ impl<'a> Formatter<'a> {
             fmt.collect_unmapped_deps(real_idx, &mut deps);
             for dep_idx in deps {
                 if emitted.insert(dep_idx) {
-                    body.push_str(&format!("  %t{} = {}\n", dep_idx, fmt.format_instruction(&fmt.instructions[dep_idx])));
+                    body.push_str(&format!(
+                        "  %t{} = {}\n",
+                        dep_idx,
+                        fmt.format_instruction(&fmt.instructions[dep_idx])
+                    ));
                 }
             }
 
@@ -263,13 +293,20 @@ impl<'a> Formatter<'a> {
                     format!("br {}({});", label_str, args)
                 }
             }
-            InstructionType::Cbr { then_label, else_label, then_args, else_args } => {
+            InstructionType::Cbr {
+                then_label,
+                else_label,
+                then_args,
+                else_args,
+            } => {
                 let cond = self.fmt_value(&instr.operands.ptr_to(0));
                 format!(
                     "cbr {}, {}({}), {}({});",
                     cond,
-                    self.fmt_label_ref(then_label), self.fmt_value_range(then_args),
-                    self.fmt_label_ref(else_label), self.fmt_value_range(else_args),
+                    self.fmt_label_ref(then_label),
+                    self.fmt_value_range(then_args),
+                    self.fmt_label_ref(else_label),
+                    self.fmt_value_range(else_args),
                 )
             }
             InstructionType::Ret => format!("ret {};", self.fmt_value(&instr.operands.ptr_to(0))),
@@ -292,30 +329,56 @@ impl<'a> Formatter<'a> {
 
             InstructionType::GetField(u) => {
                 let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
-                format!("getfield {}, {}, {};", ty_str, self.fmt_value(&instr.operands.ptr_to(0)), u)
+                format!(
+                    "getfield {}, {}, {};",
+                    ty_str,
+                    self.fmt_value(&instr.operands.ptr_to(0)),
+                    u
+                )
             }
             InstructionType::SetField(u) => {
                 let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
-                format!("setfield {}, {}, {};", ty_str, self.fmt_value(&instr.operands.ptr_to(0)), u)
+                format!(
+                    "setfield {}, {}, {};",
+                    ty_str,
+                    self.fmt_value(&instr.operands.ptr_to(0)),
+                    u
+                )
             }
             InstructionType::FunctionCall(func) => {
                 let args = self.fmt_operands_range(0, instr.operands.len(), &instr.operands);
                 format!("call f{}, {};", func.ptr(), args)
             }
             InstructionType::Allocate(_) => {
-                format!("allocate {};", self.fmt_type(&self.types.get_type(instr.value_type)))
+                format!(
+                    "allocate {};",
+                    self.fmt_type(&self.types.get_type(instr.value_type))
+                )
             }
             InstructionType::Write(slot) => {
                 let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
-                format!("write {}, ${}, {};", ty_str, slot.ptr(), self.fmt_value(&instr.operands.ptr_to(0)))
+                format!(
+                    "write {}, ${}, {};",
+                    ty_str,
+                    slot.ptr(),
+                    self.fmt_value(&instr.operands.ptr_to(0))
+                )
             }
             InstructionType::Read => {
                 let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
-                format!("read {}, {};", ty_str, self.fmt_value(&instr.operands.ptr_to(0)))
+                format!(
+                    "read {}, {};",
+                    ty_str,
+                    self.fmt_value(&instr.operands.ptr_to(0))
+                )
             }
             InstructionType::Reinterpret => {
                 let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
-                format!("reinterpret {}, {};", ty_str, self.fmt_value(&instr.operands.ptr_to(0)))
+                format!(
+                    "reinterpret {}, {};",
+                    ty_str,
+                    self.fmt_value(&instr.operands.ptr_to(0))
+                )
             }
             InstructionType::RawValue => self.fmt_value(&instr.operands.ptr_to(0)),
             InstructionType::Struct | InstructionType::Component => {
@@ -339,7 +402,9 @@ impl<'a> Formatter<'a> {
                 if matches!(instr.instruction_type, InstructionType::RawValue) {
                     self.fmt_value(&instr.operands.ptr_to(0))
                 } else if self.inline_set.contains(&p.ptr()) {
-                    self.format_instruction(instr).trim_end_matches(';').to_string()
+                    self.format_instruction(instr)
+                        .trim_end_matches(';')
+                        .to_string()
                 } else {
                     format!("%t{}", p.ptr())
                 }
@@ -360,11 +425,17 @@ impl<'a> Formatter<'a> {
     }
 
     fn fmt_value_range(&self, ptr: &IRPointer<Value>) -> String {
-        (0..ptr.len()).map(|i| self.fmt_value(&ptr.ptr_to(i))).collect::<Vec<_>>().join(", ")
+        (0..ptr.len())
+            .map(|i| self.fmt_value(&ptr.ptr_to(i)))
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 
     fn fmt_operands_range(&self, start: usize, len: usize, base: &IRPointer<Value>) -> String {
-        (start..start + len).map(|i| self.fmt_value(&base.ptr_to(i))).collect::<Vec<_>>().join(", ")
+        (start..start + len)
+            .map(|i| self.fmt_value(&base.ptr_to(i)))
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 
     fn fmt_binary(&self, op: &str, instr: &Instruction) -> String {
@@ -381,17 +452,25 @@ impl<'a> Formatter<'a> {
     // --- inline / unmapped dep helpers ---
 
     fn is_mapped(&self, instr_idx: usize) -> bool {
-        self.instruction_pointers.iter().any(|p| p.ptr() == instr_idx)
+        self.instruction_pointers
+            .iter()
+            .any(|p| p.ptr() == instr_idx)
     }
 
     fn is_inlinable(instr: &Instruction) -> bool {
-        matches!(instr.instruction_type, InstructionType::Component | InstructionType::Struct)
+        matches!(
+            instr.instruction_type,
+            InstructionType::Component | InstructionType::Struct
+        )
     }
 
-    fn produces_value(& self, instr: &Instruction) -> bool {
+    fn produces_value(&self, instr: &Instruction) -> bool {
         !matches!(
             instr.instruction_type,
-            InstructionType::Br(_) | InstructionType::Cbr { .. } | InstructionType::Write(_) | InstructionType::Ret
+            InstructionType::Br(_)
+                | InstructionType::Cbr { .. }
+                | InstructionType::Write(_)
+                | InstructionType::Ret
         )
     }
 
@@ -400,7 +479,10 @@ impl<'a> Formatter<'a> {
         for i in 0..instr.operands.len() {
             if let Value::Instruction(p) = &self.values[instr.operands.ptr_to(i).ptr()] {
                 let dep = p.ptr();
-                if matches!(self.instructions[dep].instruction_type, InstructionType::RawValue) {
+                if matches!(
+                    self.instructions[dep].instruction_type,
+                    InstructionType::RawValue
+                ) {
                     continue;
                 }
                 if !self.is_mapped(dep) {
@@ -432,7 +514,10 @@ impl<'a> Formatter<'a> {
         for i in 0..instr.operands.len() {
             if let Value::Instruction(p) = &self.values[instr.operands.ptr_to(i).ptr()] {
                 let dep_idx = p.ptr();
-                if matches!(self.instructions[dep_idx].instruction_type, InstructionType::RawValue) {
+                if matches!(
+                    self.instructions[dep_idx].instruction_type,
+                    InstructionType::RawValue
+                ) {
                     continue;
                 }
                 if self.inline_set.contains(&dep_idx) {

--- a/middleend/src/ir/visualize/formatter.rs
+++ b/middleend/src/ir/visualize/formatter.rs
@@ -79,8 +79,24 @@ impl<'a> Formatter<'a> {
             }
         }
     }
-    pub fn format_type(&self, ty: IRTypeId) -> String {
-        self.fmt_type(&self.types.get_type(ty))
+
+    pub fn format_types(&self) -> String {
+        let mut out = String::new();
+        for (name, fields) in self
+            .types
+            .structs()
+            .iter()
+            .filter_map(|s| s.name().map(|name| (name, s.get_fields())))
+        {
+            let fields = fields
+                .iter()
+                .map(|f| self.fmt_type(&self.types.get_type(*f)))
+                .collect::<Vec<_>>()
+                .join(",");
+            let v = format!("struct %{}{{{}}};\n", self.symbols.get_name(name), fields);
+            out.push_str(&v);
+        }
+        out
     }
 
     pub fn format_label(&self, label: &Label, idx: usize, instructions: &[Instruction]) -> String {

--- a/middleend/src/ir/visualize/formatter.rs
+++ b/middleend/src/ir/visualize/formatter.rs
@@ -1,8 +1,8 @@
 use common::SymbolsModule;
 
 use crate::{
-    Context, IRPointer, IRSpecializedComponentType, IRType, IRTypeId, IRTypes, Instruction,
-    InstructionType, Label, Operand, Slot, Value,
+    Context, IRComponentId, IRPointer, IRSpecializedComponentType, IRStructId, IRType, IRTypeId,
+    IRTypes, Instruction, InstructionType, Label, Operand, Slot, Value,
 };
 
 /// Formatter holds the slices and helpers necessary to render the IR in textual form (SIR).
@@ -36,6 +36,31 @@ impl<'a> Formatter<'a> {
             symbols,
         }
     }
+
+    fn fmt_struct(&self, t: &IRStructId) -> String {
+        let strukt = self.types.get_object_type(*t);
+        if let Some(name) = strukt.name() {
+            format!("%{}", self.symbols.get_name(name))
+        } else {
+            let fields = self
+                .types
+                .get_object_type(*t)
+                .get_fields()
+                .iter()
+                .map(|v| {
+                    let t = self.types.get_type(*v);
+                    self.fmt_type(&t)
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("{{{fields}}}")
+        }
+    }
+
+    fn fmt_component(&self, t: &IRComponentId) -> String {
+        let component = self.types.get_component_type(*t);
+        format!("%{}", self.symbols.get_name(component.name()))
+    }
     /// Convert IRType into a human friendly string. Kept as a free fn for reuse inside the module.
     fn fmt_type(&self, ty: &IRType) -> String {
         match ty {
@@ -52,26 +77,8 @@ impl<'a> Formatter<'a> {
             IRType::BOOL => "bool".to_string(),
             IRType::VOID => "void".to_string(),
             IRType::STR => "str".to_string(),
-            IRType::Struct(t) => {
-                let strukt = self.types.get_object_type(*t);
-                if let Some(name) = strukt.name() {
-                    format!("%{}", self.symbols.get_name(name))
-                } else {
-                    let fields = self
-                        .types
-                        .get_object_type(*t)
-                        .get_fields()
-                        .iter()
-                        .map(|v| {
-                            let t = self.types.get_type(*v);
-                            self.fmt_type(&t)
-                        })
-                        .collect::<Vec<_>>()
-                        .join(",");
-                    format!("{{{fields}}}")
-                }
-            }
-            IRType::Component(_) => "component".to_string(),
+            IRType::Struct(t) => self.fmt_struct(t),
+            IRType::Component(c) => self.fmt_component(c),
             IRType::Function(_) => "fn".to_string(),
             IRType::GenericComponent => "component".to_string(),
             IRType::ISIZE => "isize".to_string(),

--- a/middleend/src/ir/visualize/formatter.rs
+++ b/middleend/src/ir/visualize/formatter.rs
@@ -10,6 +10,7 @@ use crate::{
 /// `visualize` module.
 pub struct Formatter<'a> {
     pub labels: &'a [Label],
+    pub contexts: &'a [Context],
     pub values: &'a [Value],
     pub operands: &'a [Operand],
     pub types: &'a IRTypes,
@@ -20,12 +21,14 @@ impl<'a> Formatter<'a> {
     /// Create a new formatter instance.
     pub fn new(
         labels: &'a [Label],
+        contexts: &'a [Context],
         values: &'a [Value],
         operands: &'a [Operand],
         types: &'a IRTypes,
         symbols: &'a SymbolsModule,
     ) -> Self {
         Self {
+            contexts,
             labels,
             values,
             operands,
@@ -80,6 +83,28 @@ impl<'a> Formatter<'a> {
         }
     }
 
+    pub fn format_contexts(&self, instructions: &[Instruction]) -> String {
+        let mut out = Vec::new();
+        for ctx in self.contexts {
+            let ty = ctx.ty();
+            let IRType::Function(fty) = self.types.get_type(ty) else {
+                unreachable!("Type of context should be function");
+            };
+            let ty = self.types.get_function_type(fty);
+            let ty = self.fmt_type(&self.types.get_type(ty.get_return_type()));
+            let mut current = format!("{ty} {}(){{\n", self.symbols.get_name(ctx.name()));
+            let range = ctx.labels_ptr().range();
+            let mut idx = 0;
+            for label in &self.labels[range.start..range.end] {
+                current.push_str(&self.format_label(&label, idx, instructions));
+                idx += 1;
+            }
+            current.push_str("}\n");
+            out.push(current);
+        }
+        out.join("\n")
+    }
+
     pub fn format_types(&self) -> String {
         let mut out = String::new();
         for (name, fields) in self
@@ -125,6 +150,7 @@ impl<'a> Formatter<'a> {
 
             let fmt = Formatter::new(
                 self.labels,
+                self.contexts,
                 self.values,
                 self.operands,
                 self.types,
@@ -257,7 +283,7 @@ impl<'a> Formatter<'a> {
         let target = self.fmt_value(&instr.operands.ptr_to(0));
         // slot here is an index into struct fields (not an IRPointer)
         let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
-        format!("set {}, {}, {};", ty_str, target, slot)
+        format!("setfield {}, {}, {};", ty_str, target, slot)
     }
 
     fn fmt_function_call(&self, instr: &Instruction, func: &IRPointer<Context, 1>) -> String {

--- a/middleend/src/ir/visualize/formatter.rs
+++ b/middleend/src/ir/visualize/formatter.rs
@@ -1,8 +1,11 @@
+use std::collections::{BTreeSet, HashMap, HashSet};
+
 use common::SymbolsModule;
 
 use crate::{
-    Context, IRComponentId, IRPointer, IRSpecializedComponentType, IRStructId, IRType, IRTypeId,
-    IRTypes, Instruction, InstructionType, Label, Operand, Slot, Value,
+    Component, Context, IRComponentId, IRPointer, IRSpecializedComponent,
+    IRSpecializedComponentType, IRStructId, IRType, IRTypes, Instruction, InstructionType, Label,
+    Operand, Slot, Value,
 };
 
 /// Formatter holds the slices and helpers necessary to render the IR in textual form (SIR).
@@ -11,10 +14,17 @@ use crate::{
 pub struct Formatter<'a> {
     pub labels: &'a [Label],
     pub contexts: &'a [Context],
+    pub components: &'a [Component],
     pub values: &'a [Value],
     pub operands: &'a [Operand],
     pub types: &'a IRTypes,
     pub symbols: &'a SymbolsModule,
+    pub specialized: &'a [IRSpecializedComponent],
+    pub instruction_pointers: &'a [IRPointer<Instruction>],
+    pub instructions: &'a [Instruction],
+    label_offset: usize,
+    /// Indices of unmapped instructions that should be inlined (used exactly once, simple op).
+    inline_set: HashSet<usize>,
 }
 
 impl<'a> Formatter<'a> {
@@ -22,19 +32,84 @@ impl<'a> Formatter<'a> {
     pub fn new(
         labels: &'a [Label],
         contexts: &'a [Context],
+        components: &'a [Component],
         values: &'a [Value],
         operands: &'a [Operand],
         types: &'a IRTypes,
         symbols: &'a SymbolsModule,
+        specialized: &'a [IRSpecializedComponent],
+        instruction_pointers: &'a [IRPointer<Instruction>],
+        instructions: &'a [Instruction],
     ) -> Self {
         Self {
             contexts,
+            components,
             labels,
             values,
             operands,
             types,
             symbols,
+            specialized,
+            instruction_pointers,
+            instructions,
+            label_offset: 0,
+            inline_set: HashSet::new(),
         }
+    }
+
+    fn with_label_offset(&self, offset: usize) -> Formatter<'a> {
+        Formatter { label_offset: offset, inline_set: HashSet::new(), ..*self }
+    }
+
+    /// Returns true if the instruction at `instr_idx` (index into `instructions`) is mapped.
+    fn is_mapped(&self, instr_idx: usize) -> bool {
+        self.instruction_pointers.iter().any(|p| p.ptr() == instr_idx)
+    }
+
+    /// Returns true if an unmapped instruction is simple enough to be inlined.
+    fn is_inlinable(instr: &Instruction) -> bool {
+        matches!(
+            instr.instruction_type,
+            InstructionType::Component | InstructionType::Struct
+        )
+    }
+
+    /// Counts how many times each unmapped instruction index is referenced by the operands
+    /// of `instr_idx` (recursively), excluding RawValue which are always inlined.
+    fn count_refs(&self, instr_idx: usize, counts: &mut HashMap<usize, usize>) {
+        let instr = &self.instructions[instr_idx];
+        for i in 0..instr.operands.len() {
+            if let Value::Instruction(p) = &self.values[instr.operands.ptr_to(i).ptr()] {
+                let dep = p.ptr();
+                let dep_instr = &self.instructions[dep];
+                if matches!(dep_instr.instruction_type, InstructionType::RawValue) {
+                    continue;
+                }
+                if !self.is_mapped(dep) {
+                    *counts.entry(dep).or_insert(0) += 1;
+                    if *counts.get(&dep).unwrap() == 1 {
+                        self.count_refs(dep, counts);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Builds the inline_set for a label: unmapped instructions referenced exactly once
+    /// that are simple enough to inline.
+    fn build_inline_set(&self, label: &Label) -> HashSet<usize> {
+        let iptr = label.instructions();
+        let mut counts: HashMap<usize, usize> = HashMap::new();
+        for i in 0..iptr.len() {
+            let ip_idx = iptr.ptr_to(i).ptr();
+            let real_idx = self.instruction_pointers[ip_idx].ptr();
+            self.count_refs(real_idx, &mut counts);
+        }
+        counts
+            .into_iter()
+            .filter(|(idx, count)| *count == 1 && Self::is_inlinable(&self.instructions[*idx]))
+            .map(|(idx, _)| idx)
+            .collect()
     }
 
     fn fmt_struct(&self, t: &IRStructId) -> String {
@@ -90,7 +165,7 @@ impl<'a> Formatter<'a> {
         }
     }
 
-    pub fn format_contexts(&self, instructions: &[Instruction]) -> String {
+    pub fn format_contexts(&self) -> String {
         let mut out = Vec::new();
         for ctx in self.contexts {
             let ty = ctx.ty();
@@ -100,12 +175,65 @@ impl<'a> Formatter<'a> {
             let ty = self.types.get_function_type(fty);
             let ty = self.fmt_type(&self.types.get_type(ty.get_return_type()));
             let mut current = format!("{ty} {}(){{\n", self.symbols.get_name(ctx.name()));
-            let range = ctx.labels_ptr().range();
+            let labels_ptr = ctx.labels_ptr();
+            let label_offset = labels_ptr.ptr();
+            let range = labels_ptr.range();
+            let fmt = self.with_label_offset(label_offset);
             let mut idx = 0;
             for label in &self.labels[range.start..range.end] {
-                current.push_str(&self.format_label(&label, idx, instructions));
+                current.push_str(&fmt.format_label(label, idx));
                 idx += 1;
             }
+            current.push_str("}\n");
+            out.push(current);
+        }
+
+        for component in self.components {
+            let ty = component.ir_type();
+            let IRType::Component(cid) = self.types.get_type(ty) else {
+                unreachable!("Type of context should be component");
+            };
+            let comp_ty = self.types.get_component_type(cid);
+            let params = comp_ty
+                .fields()
+                .iter()
+                .map(|v| self.fmt_type(&self.types.get_type(*v)))
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            let mut current = format!(
+                "component %{}({}) {{\n",
+                self.symbols.get_name(comp_ty.name()),
+                params
+            );
+
+            // Props: %fieldN: ty = pN
+            for (i, field_ty) in comp_ty.fields().iter().enumerate() {
+                let ty_str = self.fmt_type(&self.types.get_type(*field_ty));
+                current.push_str(&format!("  %field{}: {} = p{};\n", i, ty_str, i));
+            }
+
+            // Children: #tN: specialized <type>
+            let values_range = component.values();
+            for i in 0..values_range.len() {
+                let val = &self.values[values_range.ptr_to(i).ptr()];
+                let child_str = match val {
+                    Value::Instruction(instr_ptr) => {
+                        format!("#t{}: component %t{}", i, instr_ptr.ptr())
+                    }
+                    Value::Specliazed(spec_ptr) => {
+                        let spec = &self.specialized[spec_ptr.ptr()];
+                        let kind = match spec {
+                            IRSpecializedComponent::Text(_) => "specialized(text)",
+                            IRSpecializedComponent::Div(_) => "specialized(div)",
+                        };
+                        format!("#t{}: {}", i, kind)
+                    }
+                    _ => format!("#t{}: unknown", i),
+                };
+                current.push_str(&format!("  {};\n", child_str));
+            }
+
             current.push_str("}\n");
             out.push(current);
         }
@@ -131,7 +259,29 @@ impl<'a> Formatter<'a> {
         out
     }
 
-    pub fn format_label(&self, label: &Label, idx: usize, instructions: &[Instruction]) -> String {
+    /// Recursively collects indices (into `instructions`) of unmapped instructions
+    /// that `instr_idx` depends on, in ascending order, into `out`.
+    fn collect_unmapped_deps(&self, instr_idx: usize, out: &mut BTreeSet<usize>) {
+        let instr = &self.instructions[instr_idx];
+        for i in 0..instr.operands.len() {
+            let val_ptr = instr.operands.ptr_to(i);
+            if let Value::Instruction(p) = &self.values[val_ptr.ptr()] {
+                let dep_idx = p.ptr();
+                let dep_instr = &self.instructions[dep_idx];
+                if matches!(dep_instr.instruction_type, InstructionType::RawValue) {
+                    continue;
+                }
+                if self.inline_set.contains(&dep_idx) {
+                    continue; // will be inlined, no need to emit as own line
+                }
+                if !self.is_mapped(dep_idx) && out.insert(dep_idx) {
+                    self.collect_unmapped_deps(dep_idx, out);
+                }
+            }
+        }
+    }
+
+    pub fn format_label(&self, label: &Label, idx: usize) -> String {
         let mut out = String::new();
 
         if label.arguments().is_empty() {
@@ -144,27 +294,31 @@ impl<'a> Formatter<'a> {
                 .map(|(i, _)| format!("lp{}", i))
                 .collect::<Vec<_>>()
                 .join(", ");
-
             out.push_str(&format!("$label_{}({}):\n", idx, params));
         }
 
-        // Instructions inside the label
+        let inline_set = self.build_inline_set(label);
+        let fmt = Formatter { inline_set, ..*self };
+
         let iptr = label.instructions();
+        let mut emitted: BTreeSet<usize> = BTreeSet::new();
+
         for i in 0..iptr.len() {
-            let instr_ptr = iptr.ptr_to(i);
-            let instr_idx = instr_ptr.ptr();
-            let instr = &instructions[instr_idx];
+            let ip_idx = iptr.ptr_to(i).ptr();
+            let real_idx = fmt.instruction_pointers[ip_idx].ptr();
 
-            let fmt = Formatter::new(
-                self.labels,
-                self.contexts,
-                self.values,
-                self.operands,
-                self.types,
-                self.symbols,
-            );
+            let mut deps = BTreeSet::new();
+            fmt.collect_unmapped_deps(real_idx, &mut deps);
+            for dep_idx in deps {
+                if emitted.insert(dep_idx) {
+                    let dep = &fmt.instructions[dep_idx];
+                    let line = fmt.format_instruction(dep);
+                    out.push_str(&format!("  %t{} = {}\n", dep_idx, line));
+                }
+            }
+
+            let instr = &fmt.instructions[real_idx];
             let line = fmt.format_instruction(instr);
-
             let produces_value = !matches!(
                 instr.instruction_type,
                 InstructionType::Br(_)
@@ -172,25 +326,22 @@ impl<'a> Formatter<'a> {
                     | InstructionType::Write(_)
                     | InstructionType::Ret
             );
-
             out.push_str("  ");
-
             if produces_value {
-                out.push_str(&format!("%t{} = {}", instr_idx, line));
+                out.push_str(&format!("%t{} = {}", real_idx, line));
             } else {
                 out.push_str(&line);
             }
-
             out.push('\n');
         }
 
         out
     }
 
-    pub fn format_labels(&self, instructions: &[Instruction]) -> String {
+    pub fn format_labels(&self) -> String {
         let mut out = String::new();
         for (i, label) in self.labels.iter().enumerate() {
-            out.push_str(&self.format_label(label, i, instructions));
+            out.push_str(&self.format_label(label, i));
             out.push('\n');
         }
         out
@@ -199,20 +350,20 @@ impl<'a> Formatter<'a> {
     pub fn format_instruction(&self, instr: &Instruction) -> String {
         match &instr.instruction_type {
             InstructionType::Br(label_ptr) => {
-                let idx = label_ptr.ptr();
+                let label_str = self.fmt_label_ref(label_ptr);
                 let len = instr.operands.len();
 
                 if len == 0 {
-                    format!("br $label_{};", idx)
+                    format!("br {};", label_str)
                 } else {
                     let args = (0..len)
                         .map(|i| self.fmt_value(&instr.operands.ptr_to(i)))
                         .collect::<Vec<_>>()
                         .join(", ");
-                    if args.len() > 0 {
-                        format!("br $label_{}({});", idx, args)
+                    if !args.is_empty() {
+                        format!("br {}({});", label_str, args)
                     } else {
-                        format!("br $label_{};", idx)
+                        format!("br {};", label_str)
                     }
                 }
             }
@@ -268,15 +419,28 @@ impl<'a> Formatter<'a> {
                 let ptr = instr.operands.ptr_to(0);
                 self.fmt_value(&ptr)
             }
-            InstructionType::Struct | InstructionType::Component => {
-                "Struct/Component not implemented".to_string()
+            InstructionType::Struct => {
+                let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
+                let args = (0..instr.operands.len())
+                    .map(|i| self.fmt_value(&instr.operands.ptr_to(i)))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{}({})", ty_str, args)
+            }
+            InstructionType::Component => {
+                let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
+                let args = (0..instr.operands.len())
+                    .map(|i| self.fmt_value(&instr.operands.ptr_to(i)))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{}({})", ty_str, args)
             }
         }
     }
 
     #[inline]
     fn fmt_label_ref(&self, ptr: &IRPointer<Label, 1>) -> String {
-        let idx = ptr.ptr();
+        let idx = ptr.ptr().saturating_sub(self.label_offset);
         format!("$label_{}", idx)
     }
 
@@ -335,7 +499,16 @@ impl<'a> Formatter<'a> {
         match &self.values[ptr.ptr()] {
             Value::FuncArg(n) => format!("p{}", n),
             Value::LabelArg(n) => format!("lp{}", n),
-            Value::Instruction(p) => format!("%t{}", p.ptr()),
+            Value::Instruction(p) => {
+                let instr = &self.instructions[p.ptr()];
+                if matches!(instr.instruction_type, InstructionType::RawValue) {
+                    self.fmt_value(&instr.operands.ptr_to(0))
+                } else if self.inline_set.contains(&p.ptr()) {
+                    self.format_instruction(instr).trim_end_matches(';').to_string()
+                } else {
+                    format!("%t{}", p.ptr())
+                }
+            }
             Value::Slot(p) => format!("${}", p.ptr()),
             Value::Raw(op_ptr) => {
                 let op = &self.operands[op_ptr.ptr()];

--- a/middleend/src/ir/visualize/formatter.rs
+++ b/middleend/src/ir/visualize/formatter.rs
@@ -1,8 +1,8 @@
 use common::SymbolsModule;
 
 use crate::{
-    Context, IRPointer, IRSpecializedComponentType, IRType, IRTypes, Instruction, InstructionType,
-    Label, Operand, Slot, Value,
+    Context, IRPointer, IRSpecializedComponentType, IRType, IRTypeId, IRTypes, Instruction,
+    InstructionType, Label, Operand, Slot, Value,
 };
 
 /// Formatter holds the slices and helpers necessary to render the IR in textual form (SIR).
@@ -33,6 +33,56 @@ impl<'a> Formatter<'a> {
             symbols,
         }
     }
+    /// Convert IRType into a human friendly string. Kept as a free fn for reuse inside the module.
+    fn fmt_type(&self, ty: &IRType) -> String {
+        match ty {
+            IRType::I8 => "i8".to_string(),
+            IRType::U8 => "u8".to_string(),
+            IRType::I16 => "i16".to_string(),
+            IRType::U16 => "u16".to_string(),
+            IRType::I32 => "i32".to_string(),
+            IRType::U32 => "u32".to_string(),
+            IRType::I64 => "i64".to_string(),
+            IRType::U64 => "u64".to_string(),
+            IRType::F32 => "f32".to_string(),
+            IRType::F64 => "f64".to_string(),
+            IRType::BOOL => "bool".to_string(),
+            IRType::VOID => "void".to_string(),
+            IRType::STR => "str".to_string(),
+            IRType::Struct(t) => {
+                let strukt = self.types.get_object_type(*t);
+                if let Some(name) = strukt.name() {
+                    format!("%{}", self.symbols.get_name(name))
+                } else {
+                    let fields = self
+                        .types
+                        .get_object_type(*t)
+                        .get_fields()
+                        .iter()
+                        .map(|v| {
+                            let t = self.types.get_type(*v);
+                            self.fmt_type(&t)
+                        })
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    format!("{{{fields}}}")
+                }
+            }
+            IRType::Component(_) => "component".to_string(),
+            IRType::Function(_) => "fn".to_string(),
+            IRType::GenericComponent => "component".to_string(),
+            IRType::ISIZE => "isize".to_string(),
+            IRType::USIZE => "usize".to_string(),
+            IRType::Specialized(IRSpecializedComponentType::Div) => "specialized(div)".to_string(),
+            IRType::Specialized(IRSpecializedComponentType::Text) => {
+                "specialized(text)".to_string()
+            }
+        }
+    }
+    pub fn format_type(&self, ty: IRTypeId) -> String {
+        self.fmt_type(&self.types.get_type(ty))
+    }
+
     pub fn format_label(&self, label: &Label, idx: usize, instructions: &[Instruction]) -> String {
         let mut out = String::new();
 
@@ -110,7 +160,11 @@ impl<'a> Formatter<'a> {
                         .map(|i| self.fmt_value(&instr.operands.ptr_to(i)))
                         .collect::<Vec<_>>()
                         .join(", ");
-                    format!("br $label_{}({});", idx, args)
+                    if args.len() > 0 {
+                        format!("br $label_{}({});", idx, args)
+                    } else {
+                        format!("br $label_{};", idx)
+                    }
                 }
             }
 
@@ -179,14 +233,14 @@ impl<'a> Formatter<'a> {
 
     fn fmt_get_field(&self, instr: &Instruction, index: usize) -> String {
         let target = self.fmt_value(&instr.operands.ptr_to(0));
-        let ty_str = fmt_type(&self.types.get_type(instr.value_type));
+        let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
         format!("getfield {}, {}, {};", ty_str, target, index)
     }
 
     fn fmt_set_field(&self, instr: &Instruction, slot: usize) -> String {
         let target = self.fmt_value(&instr.operands.ptr_to(0));
         // slot here is an index into struct fields (not an IRPointer)
-        let ty_str = fmt_type(&self.types.get_type(instr.value_type));
+        let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
         format!("set {}, {}, {};", ty_str, target, slot)
     }
 
@@ -202,26 +256,29 @@ impl<'a> Formatter<'a> {
     }
 
     fn fmt_allocate(&self, instr: &Instruction) -> String {
-        format!("allocate {};", instr.value_type.0)
+        format!(
+            "allocate {};",
+            self.fmt_type(&self.types.get_type(instr.value_type))
+        )
     }
 
     fn fmt_write(&self, instr: &Instruction, slot: &IRPointer<Slot, 1>) -> String {
         let value = self.fmt_value(&instr.operands.ptr_to(0));
-        let slot_str = format!("%slot{}", slot.ptr());
-        let ty_str = fmt_type(&self.types.get_type(instr.value_type));
+        let slot_str = format!("${}", slot.ptr());
+        let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
         format!("write {}, {}, {};", ty_str, slot_str, value)
     }
 
     fn fmt_read(&self, instr: &Instruction) -> String {
         let slot = instr.operands.ptr_to(0);
         let slot_str = self.fmt_value(&slot);
-        let ty_str = fmt_type(&self.types.get_type(instr.value_type));
+        let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
         format!("read {}, {};", ty_str, slot_str)
     }
 
     fn fmt_reinterpret(&self, instr: &Instruction) -> String {
         let slot_str = self.fmt_value(&instr.operands.ptr_to(0));
-        let ty_str = fmt_type(&self.types.get_type(instr.value_type));
+        let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
         format!("reinterpret {}, {};", ty_str, slot_str)
     }
 
@@ -230,7 +287,7 @@ impl<'a> Formatter<'a> {
             Value::FuncArg(n) => format!("p{}", n),
             Value::LabelArg(n) => format!("lp{}", n),
             Value::Instruction(p) => format!("%t{}", p.ptr()),
-            Value::Slot(p) => format!("%slot{}", p.ptr()),
+            Value::Slot(p) => format!("${}", p.ptr()),
             Value::Raw(op_ptr) => {
                 let op = &self.operands[op_ptr.ptr()];
                 match op {
@@ -257,35 +314,7 @@ impl<'a> Formatter<'a> {
         let a = self.fmt_value(&instr.operands.ptr_to(0));
         let b = self.fmt_value(&instr.operands.ptr_to(1));
         let sla = self.types.get_type(instr.value_type);
-        let ty_str = fmt_type(&sla);
+        let ty_str = self.fmt_type(&sla);
         format!("{} {}, {}, {};", op, ty_str, a, b)
-    }
-}
-
-/// Convert IRType into a human friendly string. Kept as a free fn for reuse inside the module.
-fn fmt_type(ty: &IRType) -> String {
-    match ty {
-        IRType::I8 => "i8".to_string(),
-        IRType::U8 => "u8".to_string(),
-        IRType::I16 => "i16".to_string(),
-        IRType::U16 => "u16".to_string(),
-        IRType::I32 => "i32".to_string(),
-        IRType::U32 => "u32".to_string(),
-        IRType::I64 => "i64".to_string(),
-        IRType::U64 => "u64".to_string(),
-        IRType::F32 => "f32".to_string(),
-        IRType::F64 => "f64".to_string(),
-        IRType::BOOL => "bool".to_string(),
-        IRType::VOID => "void".to_string(),
-        IRType::STR => "str".to_string(),
-        IRType::Tuple(_) => "tuple".to_string(),
-        IRType::Struct(_) => "struct".to_string(),
-        IRType::Component(_) => "component".to_string(),
-        IRType::Function(_) => "fn".to_string(),
-        IRType::GenericComponent => "generic".to_string(),
-        IRType::ISIZE => "isize".to_string(),
-        IRType::USIZE => "usize".to_string(),
-        IRType::Specialized(IRSpecializedComponentType::Div) => "div".to_string(),
-        IRType::Specialized(IRSpecializedComponentType::Text) => "text".to_string(),
     }
 }

--- a/middleend/src/ir/visualize/formatter.rs
+++ b/middleend/src/ir/visualize/formatter.rs
@@ -8,9 +8,6 @@ use crate::{
     Operand, Slot, Value,
 };
 
-/// Formatter holds the slices and helpers necessary to render the IR in textual form (SIR).
-/// It provides instance methods that replace the free functions previously living in the
-/// `visualize` module.
 pub struct Formatter<'a> {
     pub labels: &'a [Label],
     pub contexts: &'a [Context],
@@ -20,15 +17,13 @@ pub struct Formatter<'a> {
     pub types: &'a IRTypes,
     pub symbols: &'a SymbolsModule,
     pub specialized: &'a [IRSpecializedComponent],
-    pub instruction_pointers: &'a [IRPointer<Instruction>],
-    pub instructions: &'a [Instruction],
+    instruction_pointers: &'a [IRPointer<Instruction>],
+    instructions: &'a [Instruction],
     label_offset: usize,
-    /// Indices of unmapped instructions that should be inlined (used exactly once, simple op).
     inline_set: HashSet<usize>,
 }
 
 impl<'a> Formatter<'a> {
-    /// Create a new formatter instance.
     pub fn new(
         labels: &'a [Label],
         contexts: &'a [Context],
@@ -61,82 +56,8 @@ impl<'a> Formatter<'a> {
         Formatter { label_offset: offset, inline_set: HashSet::new(), ..*self }
     }
 
-    /// Returns true if the instruction at `instr_idx` (index into `instructions`) is mapped.
-    fn is_mapped(&self, instr_idx: usize) -> bool {
-        self.instruction_pointers.iter().any(|p| p.ptr() == instr_idx)
-    }
+    // --- type formatting ---
 
-    /// Returns true if an unmapped instruction is simple enough to be inlined.
-    fn is_inlinable(instr: &Instruction) -> bool {
-        matches!(
-            instr.instruction_type,
-            InstructionType::Component | InstructionType::Struct
-        )
-    }
-
-    /// Counts how many times each unmapped instruction index is referenced by the operands
-    /// of `instr_idx` (recursively), excluding RawValue which are always inlined.
-    fn count_refs(&self, instr_idx: usize, counts: &mut HashMap<usize, usize>) {
-        let instr = &self.instructions[instr_idx];
-        for i in 0..instr.operands.len() {
-            if let Value::Instruction(p) = &self.values[instr.operands.ptr_to(i).ptr()] {
-                let dep = p.ptr();
-                let dep_instr = &self.instructions[dep];
-                if matches!(dep_instr.instruction_type, InstructionType::RawValue) {
-                    continue;
-                }
-                if !self.is_mapped(dep) {
-                    *counts.entry(dep).or_insert(0) += 1;
-                    if *counts.get(&dep).unwrap() == 1 {
-                        self.count_refs(dep, counts);
-                    }
-                }
-            }
-        }
-    }
-
-    /// Builds the inline_set for a label: unmapped instructions referenced exactly once
-    /// that are simple enough to inline.
-    fn build_inline_set(&self, label: &Label) -> HashSet<usize> {
-        let iptr = label.instructions();
-        let mut counts: HashMap<usize, usize> = HashMap::new();
-        for i in 0..iptr.len() {
-            let ip_idx = iptr.ptr_to(i).ptr();
-            let real_idx = self.instruction_pointers[ip_idx].ptr();
-            self.count_refs(real_idx, &mut counts);
-        }
-        counts
-            .into_iter()
-            .filter(|(idx, count)| *count == 1 && Self::is_inlinable(&self.instructions[*idx]))
-            .map(|(idx, _)| idx)
-            .collect()
-    }
-
-    fn fmt_struct(&self, t: &IRStructId) -> String {
-        let strukt = self.types.get_object_type(*t);
-        if let Some(name) = strukt.name() {
-            format!("%{}", self.symbols.get_name(name))
-        } else {
-            let fields = self
-                .types
-                .get_object_type(*t)
-                .get_fields()
-                .iter()
-                .map(|v| {
-                    let t = self.types.get_type(*v);
-                    self.fmt_type(&t)
-                })
-                .collect::<Vec<_>>()
-                .join(",");
-            format!("{{{fields}}}")
-        }
-    }
-
-    fn fmt_component(&self, t: &IRComponentId) -> String {
-        let component = self.types.get_component_type(*t);
-        format!("%{}", self.symbols.get_name(component.name()))
-    }
-    /// Convert IRType into a human friendly string. Kept as a free fn for reuse inside the module.
     fn fmt_type(&self, ty: &IRType) -> String {
         match ty {
             IRType::I8 => "i8".to_string(),
@@ -152,93 +73,38 @@ impl<'a> Formatter<'a> {
             IRType::BOOL => "bool".to_string(),
             IRType::VOID => "void".to_string(),
             IRType::STR => "str".to_string(),
-            IRType::Struct(t) => self.fmt_struct(t),
-            IRType::Component(c) => self.fmt_component(c),
-            IRType::Function(_) => "fn".to_string(),
-            IRType::GenericComponent => "component".to_string(),
             IRType::ISIZE => "isize".to_string(),
             IRType::USIZE => "usize".to_string(),
+            IRType::Function(_) => "fn".to_string(),
+            IRType::GenericComponent => "component".to_string(),
+            IRType::Struct(t) => self.fmt_struct_type(t),
+            IRType::Component(c) => self.fmt_component_type(c),
             IRType::Specialized(IRSpecializedComponentType::Div) => "specialized(div)".to_string(),
-            IRType::Specialized(IRSpecializedComponentType::Text) => {
-                "specialized(text)".to_string()
-            }
+            IRType::Specialized(IRSpecializedComponentType::Text) => "specialized(text)".to_string(),
         }
     }
 
-    pub fn format_contexts(&self) -> String {
-        let mut out = Vec::new();
-        for ctx in self.contexts {
-            let ty = ctx.ty();
-            let IRType::Function(fty) = self.types.get_type(ty) else {
-                unreachable!("Type of context should be function");
-            };
-            let ty = self.types.get_function_type(fty);
-            let ty = self.fmt_type(&self.types.get_type(ty.get_return_type()));
-            let mut current = format!("{ty} {}(){{\n", self.symbols.get_name(ctx.name()));
-            let labels_ptr = ctx.labels_ptr();
-            let label_offset = labels_ptr.ptr();
-            let range = labels_ptr.range();
-            let fmt = self.with_label_offset(label_offset);
-            let mut idx = 0;
-            for label in &self.labels[range.start..range.end] {
-                current.push_str(&fmt.format_label(label, idx));
-                idx += 1;
-            }
-            current.push_str("}\n");
-            out.push(current);
-        }
-
-        for component in self.components {
-            let ty = component.ir_type();
-            let IRType::Component(cid) = self.types.get_type(ty) else {
-                unreachable!("Type of context should be component");
-            };
-            let comp_ty = self.types.get_component_type(cid);
-            let params = comp_ty
-                .fields()
+    fn fmt_struct_type(&self, t: &IRStructId) -> String {
+        let strukt = self.types.get_object_type(*t);
+        if let Some(name) = strukt.name() {
+            format!("%{}", self.symbols.get_name(name))
+        } else {
+            let fields = strukt
+                .get_fields()
                 .iter()
                 .map(|v| self.fmt_type(&self.types.get_type(*v)))
                 .collect::<Vec<_>>()
-                .join(", ");
-
-            let mut current = format!(
-                "component %{}({}) {{\n",
-                self.symbols.get_name(comp_ty.name()),
-                params
-            );
-
-            // Props: %fieldN: ty = pN
-            for (i, field_ty) in comp_ty.fields().iter().enumerate() {
-                let ty_str = self.fmt_type(&self.types.get_type(*field_ty));
-                current.push_str(&format!("  %field{}: {} = p{};\n", i, ty_str, i));
-            }
-
-            // Children: #tN: specialized <type>
-            let values_range = component.values();
-            for i in 0..values_range.len() {
-                let val = &self.values[values_range.ptr_to(i).ptr()];
-                let child_str = match val {
-                    Value::Instruction(instr_ptr) => {
-                        format!("#t{}: component %t{}", i, instr_ptr.ptr())
-                    }
-                    Value::Specliazed(spec_ptr) => {
-                        let spec = &self.specialized[spec_ptr.ptr()];
-                        let kind = match spec {
-                            IRSpecializedComponent::Text(_) => "specialized(text)",
-                            IRSpecializedComponent::Div(_) => "specialized(div)",
-                        };
-                        format!("#t{}: {}", i, kind)
-                    }
-                    _ => format!("#t{}: unknown", i),
-                };
-                current.push_str(&format!("  {};\n", child_str));
-            }
-
-            current.push_str("}\n");
-            out.push(current);
+                .join(",");
+            format!("{{{fields}}}")
         }
-        out.join("\n")
     }
+
+    fn fmt_component_type(&self, t: &IRComponentId) -> String {
+        let component = self.types.get_component_type(*t);
+        format!("%{}", self.symbols.get_name(component.name()))
+    }
+
+    // --- top-level formatting ---
 
     pub fn format_types(&self) -> String {
         let mut out = String::new();
@@ -253,39 +119,81 @@ impl<'a> Formatter<'a> {
                 .map(|f| self.fmt_type(&self.types.get_type(*f)))
                 .collect::<Vec<_>>()
                 .join(",");
-            let v = format!("struct %{}{{{}}};\n", self.symbols.get_name(name), fields);
-            out.push_str(&v);
+            out.push_str(&format!("struct %{}{{{}}};\n", self.symbols.get_name(name), fields));
         }
         out
     }
 
-    /// Recursively collects indices (into `instructions`) of unmapped instructions
-    /// that `instr_idx` depends on, in ascending order, into `out`.
-    fn collect_unmapped_deps(&self, instr_idx: usize, out: &mut BTreeSet<usize>) {
-        let instr = &self.instructions[instr_idx];
-        for i in 0..instr.operands.len() {
-            let val_ptr = instr.operands.ptr_to(i);
-            if let Value::Instruction(p) = &self.values[val_ptr.ptr()] {
-                let dep_idx = p.ptr();
-                let dep_instr = &self.instructions[dep_idx];
-                if matches!(dep_instr.instruction_type, InstructionType::RawValue) {
-                    continue;
-                }
-                if self.inline_set.contains(&dep_idx) {
-                    continue; // will be inlined, no need to emit as own line
-                }
-                if !self.is_mapped(dep_idx) && out.insert(dep_idx) {
-                    self.collect_unmapped_deps(dep_idx, out);
-                }
-            }
+    pub fn format_contexts(&self) -> String {
+        let mut out = Vec::new();
+        for ctx in self.contexts {
+            out.push(self.format_function(ctx));
         }
+        for component in self.components {
+            out.push(self.format_component(component));
+        }
+        out.join("\n")
     }
 
-    pub fn format_label(&self, label: &Label, idx: usize) -> String {
-        let mut out = String::new();
+    fn format_function(&self, ctx: &Context) -> String {
+        let IRType::Function(fty) = self.types.get_type(ctx.ty()) else {
+            unreachable!("Type of context should be function");
+        };
+        let ret_ty = self.fmt_type(&self.types.get_type(self.types.get_function_type(fty).get_return_type()));
+        let mut out = format!("{ret_ty} {}(){{\n", self.symbols.get_name(ctx.name()));
 
-        if label.arguments().is_empty() {
-            out.push_str(&format!("$label_{}:\n", idx));
+        let labels_ptr = ctx.labels_ptr();
+        let fmt = self.with_label_offset(labels_ptr.ptr());
+        for (idx, label) in self.labels[labels_ptr.range()].iter().enumerate() {
+            out.push_str(&fmt.format_label(label, idx));
+        }
+        out.push_str("}\n");
+        out
+    }
+
+    fn format_component(&self, component: &Component) -> String {
+        let IRType::Component(cid) = self.types.get_type(component.ir_type()) else {
+            unreachable!("Type of component should be Component");
+        };
+        let comp_ty = self.types.get_component_type(cid);
+        let params = comp_ty
+            .fields()
+            .iter()
+            .map(|v| self.fmt_type(&self.types.get_type(*v)))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        let mut out = format!("component %{}({}) {{\n", self.symbols.get_name(comp_ty.name()), params);
+
+        for (i, field_ty) in comp_ty.fields().iter().enumerate() {
+            out.push_str(&format!("  %field{}: {} = p{};\n", i, self.fmt_type(&self.types.get_type(*field_ty)), i));
+        }
+
+        let values_range = component.values();
+        for i in 0..values_range.len() {
+            let child_str = match &self.values[values_range.ptr_to(i).ptr()] {
+                Value::Instruction(p) => format!("#t{}: component %t{}", i, p.ptr()),
+                Value::Specliazed(spec_ptr) => {
+                    let kind = match &self.specialized[spec_ptr.ptr()] {
+                        IRSpecializedComponent::Text(_) => "specialized(text)",
+                        IRSpecializedComponent::Div(_) => "specialized(div)",
+                    };
+                    format!("#t{}: {}", i, kind)
+                }
+                _ => format!("#t{}: unknown", i),
+            };
+            out.push_str(&format!("  {};\n", child_str));
+        }
+
+        out.push_str("}\n");
+        out
+    }
+
+    // --- label formatting ---
+
+    pub fn format_label(&self, label: &Label, idx: usize) -> String {
+        let header = if label.arguments().is_empty() {
+            format!("$label_{}:\n", idx)
         } else {
             let params = label
                 .arguments()
@@ -294,101 +202,77 @@ impl<'a> Formatter<'a> {
                 .map(|(i, _)| format!("lp{}", i))
                 .collect::<Vec<_>>()
                 .join(", ");
-            out.push_str(&format!("$label_{}({}):\n", idx, params));
-        }
+            format!("$label_{}({}):\n", idx, params)
+        };
 
         let inline_set = self.build_inline_set(label);
         let fmt = Formatter { inline_set, ..*self };
 
         let iptr = label.instructions();
-        let mut emitted: BTreeSet<usize> = BTreeSet::new();
+        let mut emitted = BTreeSet::new();
+        let mut body = String::new();
 
         for i in 0..iptr.len() {
-            let ip_idx = iptr.ptr_to(i).ptr();
-            let real_idx = fmt.instruction_pointers[ip_idx].ptr();
+            let real_idx = fmt.instruction_pointers[iptr.ptr_to(i).ptr()].ptr();
 
             let mut deps = BTreeSet::new();
             fmt.collect_unmapped_deps(real_idx, &mut deps);
             for dep_idx in deps {
                 if emitted.insert(dep_idx) {
-                    let dep = &fmt.instructions[dep_idx];
-                    let line = fmt.format_instruction(dep);
-                    out.push_str(&format!("  %t{} = {}\n", dep_idx, line));
+                    body.push_str(&format!("  %t{} = {}\n", dep_idx, fmt.format_instruction(&fmt.instructions[dep_idx])));
                 }
             }
 
             let instr = &fmt.instructions[real_idx];
             let line = fmt.format_instruction(instr);
-            let produces_value = !matches!(
-                instr.instruction_type,
-                InstructionType::Br(_)
-                    | InstructionType::Cbr { .. }
-                    | InstructionType::Write(_)
-                    | InstructionType::Ret
-            );
-            out.push_str("  ");
-            if produces_value {
-                out.push_str(&format!("%t{} = {}", real_idx, line));
+            body.push_str("  ");
+            if fmt.produces_value(instr) {
+                let lhs = if let InstructionType::Allocate(slot) = &instr.instruction_type {
+                    format!("${}", slot.ptr())
+                } else {
+                    format!("%t{}", real_idx)
+                };
+                body.push_str(&format!("{} = {}", lhs, line));
             } else {
-                out.push_str(&line);
+                body.push_str(&line);
             }
-            out.push('\n');
+            body.push('\n');
         }
 
-        out
+        format!("{}{}", header, body)
     }
 
     pub fn format_labels(&self) -> String {
-        let mut out = String::new();
-        for (i, label) in self.labels.iter().enumerate() {
-            out.push_str(&self.format_label(label, i));
-            out.push('\n');
-        }
-        out
+        self.labels
+            .iter()
+            .enumerate()
+            .map(|(i, label)| format!("{}\n", self.format_label(label, i)))
+            .collect()
     }
-    /// Format a single instruction into a String (the full textual representation).
+
+    // --- instruction formatting ---
+
     pub fn format_instruction(&self, instr: &Instruction) -> String {
         match &instr.instruction_type {
             InstructionType::Br(label_ptr) => {
                 let label_str = self.fmt_label_ref(label_ptr);
-                let len = instr.operands.len();
-
-                if len == 0 {
+                let args = self.fmt_operands_range(0, instr.operands.len(), &instr.operands);
+                if args.is_empty() {
                     format!("br {};", label_str)
                 } else {
-                    let args = (0..len)
-                        .map(|i| self.fmt_value(&instr.operands.ptr_to(i)))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    if !args.is_empty() {
-                        format!("br {}({});", label_str, args)
-                    } else {
-                        format!("br {};", label_str)
-                    }
+                    format!("br {}({});", label_str, args)
                 }
             }
-
-            InstructionType::Cbr {
-                then_label,
-                else_label,
-                then_args,
-                else_args,
-            } => {
+            InstructionType::Cbr { then_label, else_label, then_args, else_args } => {
                 let cond = self.fmt_value(&instr.operands.ptr_to(0));
-                let then_str = self.fmt_label_ref(then_label);
-                let else_str = self.fmt_label_ref(else_label);
-                let then_a = self.fmt_value_range(then_args);
-                let else_a = self.fmt_value_range(else_args);
                 format!(
                     "cbr {}, {}({}), {}({});",
-                    cond, then_str, then_a, else_str, else_a
+                    cond,
+                    self.fmt_label_ref(then_label), self.fmt_value_range(then_args),
+                    self.fmt_label_ref(else_label), self.fmt_value_range(else_args),
                 )
             }
-
-            InstructionType::Ret => {
-                let val = self.fmt_value(&instr.operands.ptr_to(0));
-                format!("ret {};", val)
-            }
+            InstructionType::Ret => format!("ret {};", self.fmt_value(&instr.operands.ptr_to(0))),
 
             InstructionType::Add => self.fmt_binary("add", instr),
             InstructionType::Sub => self.fmt_binary("sub", instr),
@@ -406,99 +290,50 @@ impl<'a> Formatter<'a> {
             InstructionType::Shr => self.fmt_binary("shr", instr),
             InstructionType::AShr => self.fmt_binary("ashr", instr),
 
-            InstructionType::GetField(u) => self.fmt_get_field(instr, *u),
-            InstructionType::SetField(u) => self.fmt_set_field(instr, *u),
-            InstructionType::FunctionCall(temp) => self.fmt_function_call(instr, temp),
-
-            InstructionType::Allocate(_) => self.fmt_allocate(instr),
-            InstructionType::Write(slot) => self.fmt_write(instr, slot),
-            InstructionType::Read => self.fmt_read(instr),
-            InstructionType::Reinterpret => self.fmt_reinterpret(instr),
-
-            InstructionType::RawValue => {
-                let ptr = instr.operands.ptr_to(0);
-                self.fmt_value(&ptr)
-            }
-            InstructionType::Struct => {
+            InstructionType::GetField(u) => {
                 let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
-                let args = (0..instr.operands.len())
-                    .map(|i| self.fmt_value(&instr.operands.ptr_to(i)))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                format!("{}({})", ty_str, args)
+                format!("getfield {}, {}, {};", ty_str, self.fmt_value(&instr.operands.ptr_to(0)), u)
             }
-            InstructionType::Component => {
+            InstructionType::SetField(u) => {
                 let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
-                let args = (0..instr.operands.len())
-                    .map(|i| self.fmt_value(&instr.operands.ptr_to(i)))
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                format!("{}({})", ty_str, args)
+                format!("setfield {}, {}, {};", ty_str, self.fmt_value(&instr.operands.ptr_to(0)), u)
+            }
+            InstructionType::FunctionCall(func) => {
+                let args = self.fmt_operands_range(0, instr.operands.len(), &instr.operands);
+                format!("call f{}, {};", func.ptr(), args)
+            }
+            InstructionType::Allocate(_) => {
+                format!("allocate {};", self.fmt_type(&self.types.get_type(instr.value_type)))
+            }
+            InstructionType::Write(slot) => {
+                let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
+                format!("write {}, ${}, {};", ty_str, slot.ptr(), self.fmt_value(&instr.operands.ptr_to(0)))
+            }
+            InstructionType::Read => {
+                let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
+                format!("read {}, {};", ty_str, self.fmt_value(&instr.operands.ptr_to(0)))
+            }
+            InstructionType::Reinterpret => {
+                let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
+                format!("reinterpret {}, {};", ty_str, self.fmt_value(&instr.operands.ptr_to(0)))
+            }
+            InstructionType::RawValue => self.fmt_value(&instr.operands.ptr_to(0)),
+            InstructionType::Struct | InstructionType::Component => {
+                let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
+                let args = self.fmt_operands_range(0, instr.operands.len(), &instr.operands);
+                format!("{}({});", ty_str, args)
             }
         }
     }
 
-    #[inline]
-    fn fmt_label_ref(&self, ptr: &IRPointer<Label, 1>) -> String {
-        let idx = ptr.ptr().saturating_sub(self.label_offset);
-        format!("$label_{}", idx)
-    }
-
-    fn fmt_get_field(&self, instr: &Instruction, index: usize) -> String {
-        let target = self.fmt_value(&instr.operands.ptr_to(0));
-        let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
-        format!("getfield {}, {}, {};", ty_str, target, index)
-    }
-
-    fn fmt_set_field(&self, instr: &Instruction, slot: usize) -> String {
-        let target = self.fmt_value(&instr.operands.ptr_to(0));
-        // slot here is an index into struct fields (not an IRPointer)
-        let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
-        format!("setfield {}, {}, {};", ty_str, target, slot)
-    }
-
-    fn fmt_function_call(&self, instr: &Instruction, func: &IRPointer<Context, 1>) -> String {
-        let args = (0..instr.operands.len())
-            .map(|i| self.fmt_value(&instr.operands.ptr_to(i)))
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        let fname = format!("f{}", func.ptr());
-
-        format!("call {}, {};", fname, args)
-    }
-
-    fn fmt_allocate(&self, instr: &Instruction) -> String {
-        format!(
-            "allocate {};",
-            self.fmt_type(&self.types.get_type(instr.value_type))
-        )
-    }
-
-    fn fmt_write(&self, instr: &Instruction, slot: &IRPointer<Slot, 1>) -> String {
-        let value = self.fmt_value(&instr.operands.ptr_to(0));
-        let slot_str = format!("${}", slot.ptr());
-        let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
-        format!("write {}, {}, {};", ty_str, slot_str, value)
-    }
-
-    fn fmt_read(&self, instr: &Instruction) -> String {
-        let slot = instr.operands.ptr_to(0);
-        let slot_str = self.fmt_value(&slot);
-        let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
-        format!("read {}, {};", ty_str, slot_str)
-    }
-
-    fn fmt_reinterpret(&self, instr: &Instruction) -> String {
-        let slot_str = self.fmt_value(&instr.operands.ptr_to(0));
-        let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
-        format!("reinterpret {}, {};", ty_str, slot_str)
-    }
+    // --- value / operand helpers ---
 
     fn fmt_value(&self, ptr: &IRPointer<Value, 1>) -> String {
         match &self.values[ptr.ptr()] {
             Value::FuncArg(n) => format!("p{}", n),
             Value::LabelArg(n) => format!("lp{}", n),
+            Value::Slot(p) => format!("${}", p.ptr()),
+            Value::Raw(op_ptr) => self.fmt_operand(&self.operands[op_ptr.ptr()]),
             Value::Instruction(p) => {
                 let instr = &self.instructions[p.ptr()];
                 if matches!(instr.instruction_type, InstructionType::RawValue) {
@@ -509,34 +344,104 @@ impl<'a> Formatter<'a> {
                     format!("%t{}", p.ptr())
                 }
             }
-            Value::Slot(p) => format!("${}", p.ptr()),
-            Value::Raw(op_ptr) => {
-                let op = &self.operands[op_ptr.ptr()];
-                match op {
-                    Operand::Bool(b) => b.to_string(),
-                    Operand::Int(i) => i.to_string(),
-                    Operand::Float(f) => f.to_string(),
-                    Operand::String(sym) => format!("\"{}\"", self.symbols.get_name(*sym)),
-                }
-            }
             Value::StructLiteral(_, _) => format!("%lit{}", ptr.ptr()),
             Value::Void => "void".to_string(),
-            Value::Specliazed(_) => "Specialized not implemented".to_string(),
+            Value::Specliazed(_) => "specialized".to_string(),
+        }
+    }
+
+    fn fmt_operand(&self, op: &Operand) -> String {
+        match op {
+            Operand::Bool(b) => b.to_string(),
+            Operand::Int(i) => i.to_string(),
+            Operand::Float(f) => f.to_string(),
+            Operand::String(sym) => format!("\"{}\"", self.symbols.get_name(*sym)),
         }
     }
 
     fn fmt_value_range(&self, ptr: &IRPointer<Value>) -> String {
-        (0..ptr.len())
-            .map(|i| self.fmt_value(&ptr.ptr_to(i)))
-            .collect::<Vec<_>>()
-            .join(", ")
+        (0..ptr.len()).map(|i| self.fmt_value(&ptr.ptr_to(i))).collect::<Vec<_>>().join(", ")
+    }
+
+    fn fmt_operands_range(&self, start: usize, len: usize, base: &IRPointer<Value>) -> String {
+        (start..start + len).map(|i| self.fmt_value(&base.ptr_to(i))).collect::<Vec<_>>().join(", ")
     }
 
     fn fmt_binary(&self, op: &str, instr: &Instruction) -> String {
+        let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
         let a = self.fmt_value(&instr.operands.ptr_to(0));
         let b = self.fmt_value(&instr.operands.ptr_to(1));
-        let sla = self.types.get_type(instr.value_type);
-        let ty_str = self.fmt_type(&sla);
         format!("{} {}, {}, {};", op, ty_str, a, b)
+    }
+
+    fn fmt_label_ref(&self, ptr: &IRPointer<Label, 1>) -> String {
+        format!("$label_{}", ptr.ptr().saturating_sub(self.label_offset))
+    }
+
+    // --- inline / unmapped dep helpers ---
+
+    fn is_mapped(&self, instr_idx: usize) -> bool {
+        self.instruction_pointers.iter().any(|p| p.ptr() == instr_idx)
+    }
+
+    fn is_inlinable(instr: &Instruction) -> bool {
+        matches!(instr.instruction_type, InstructionType::Component | InstructionType::Struct)
+    }
+
+    fn produces_value(& self, instr: &Instruction) -> bool {
+        !matches!(
+            instr.instruction_type,
+            InstructionType::Br(_) | InstructionType::Cbr { .. } | InstructionType::Write(_) | InstructionType::Ret
+        )
+    }
+
+    fn count_refs(&self, instr_idx: usize, counts: &mut HashMap<usize, usize>) {
+        let instr = &self.instructions[instr_idx];
+        for i in 0..instr.operands.len() {
+            if let Value::Instruction(p) = &self.values[instr.operands.ptr_to(i).ptr()] {
+                let dep = p.ptr();
+                if matches!(self.instructions[dep].instruction_type, InstructionType::RawValue) {
+                    continue;
+                }
+                if !self.is_mapped(dep) {
+                    *counts.entry(dep).or_insert(0) += 1;
+                    if *counts.get(&dep).unwrap() == 1 {
+                        self.count_refs(dep, counts);
+                    }
+                }
+            }
+        }
+    }
+
+    fn build_inline_set(&self, label: &Label) -> HashSet<usize> {
+        let iptr = label.instructions();
+        let mut counts = HashMap::new();
+        for i in 0..iptr.len() {
+            let real_idx = self.instruction_pointers[iptr.ptr_to(i).ptr()].ptr();
+            self.count_refs(real_idx, &mut counts);
+        }
+        counts
+            .into_iter()
+            .filter(|(idx, count)| *count == 1 && Self::is_inlinable(&self.instructions[*idx]))
+            .map(|(idx, _)| idx)
+            .collect()
+    }
+
+    fn collect_unmapped_deps(&self, instr_idx: usize, out: &mut BTreeSet<usize>) {
+        let instr = &self.instructions[instr_idx];
+        for i in 0..instr.operands.len() {
+            if let Value::Instruction(p) = &self.values[instr.operands.ptr_to(i).ptr()] {
+                let dep_idx = p.ptr();
+                if matches!(self.instructions[dep_idx].instruction_type, InstructionType::RawValue) {
+                    continue;
+                }
+                if self.inline_set.contains(&dep_idx) {
+                    continue;
+                }
+                if !self.is_mapped(dep_idx) && out.insert(dep_idx) {
+                    self.collect_unmapped_deps(dep_idx, out);
+                }
+            }
+        }
     }
 }

--- a/middleend/src/types/irtype.rs
+++ b/middleend/src/types/irtype.rs
@@ -1,6 +1,5 @@
 use crate::{
-    IRComponentId, IRSpecializedComponentType, IRStructId, IRTupleId,
-    types::functions::IRFunctionId,
+    IRComponentId, IRSpecializedComponentType, IRStructId, types::functions::IRFunctionId,
 };
 
 /// Logical identifier for a type inside IR type storage.
@@ -23,7 +22,6 @@ pub enum IRType {
     BOOL,
     VOID,
     GenericComponent,
-    Tuple(IRTupleId),
     Specialized(IRSpecializedComponentType),
     Component(IRComponentId),
     Struct(IRStructId),

--- a/middleend/src/types/mod.rs
+++ b/middleend/src/types/mod.rs
@@ -50,6 +50,13 @@ impl IRTypes {
         }
     }
 
+    pub fn structs(&self) -> &[IRStruct] {
+        &self.structs
+    }
+    pub fn components(&self) -> &[IRStruct] {
+        &self.structs
+    }
+
     ///Checks if the provided `ty` is some variant of unsigned int
     pub fn is_negative_int(&self, ty: IRTypeId) -> bool {
         let index = self.usize_type().0;

--- a/middleend/src/types/mod.rs
+++ b/middleend/src/types/mod.rs
@@ -3,6 +3,7 @@ mod functions;
 mod irtype;
 mod structs;
 mod tuple;
+use common::SymbolPointer;
 pub use components::*;
 pub use functions::*;
 pub use irtype::*;
@@ -75,7 +76,7 @@ impl IRTypes {
     }
 
     ///Gets a mutable referente to the type of the function with the provided `id`
-    pub fn get_object_type(&mut self, id: IRStructId) -> &IRStruct {
+    pub fn get_object_type(&self, id: IRStructId) -> &IRStruct {
         &self.structs[id.0]
     }
     ///Gets a mutable referente to the type of the function with the provided `id`
@@ -161,9 +162,9 @@ impl IRTypes {
             .unwrap()
     }
     ///Creates a new empty struct and returns its type ID
-    pub fn create_empty_struct(&mut self) -> IRTypeId {
+    pub fn create_empty_struct(&mut self, name: SymbolPointer) -> IRTypeId {
         let sout = self.structs.len();
-        self.structs.push(IRStruct::new());
+        self.structs.push(IRStruct::new(Some(name)));
         let out = self.types.len();
         self.types.push(IRType::Struct(IRStructId(sout)));
         IRTypeId(out)
@@ -195,7 +196,7 @@ impl IRTypes {
                 );
             }
         }
-        let mut s = IRStruct::new();
+        let mut s = IRStruct::new(None);
         for field in elements {
             s.insert_field(field);
         }

--- a/middleend/src/types/structs.rs
+++ b/middleend/src/types/structs.rs
@@ -1,3 +1,4 @@
+use common::SymbolPointer;
 use smallvec::SmallVec;
 
 use crate::IRTypeId;
@@ -5,6 +6,7 @@ use crate::IRTypeId;
 #[derive(Debug, Default)]
 pub struct IRStruct {
     fields: SmallVec<[IRTypeId; 8]>,
+    name: Option<SymbolPointer>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -13,9 +15,10 @@ pub struct IRStructId(pub usize);
 
 impl IRStruct {
     ///Creates a new empty struct
-    pub fn new() -> Self {
+    pub fn new(name: Option<SymbolPointer>) -> Self {
         IRStruct {
             fields: SmallVec::new(),
+            name,
         }
     }
     ///Inserts the provided `field` onto this struct's fields
@@ -25,5 +28,9 @@ impl IRStruct {
 
     pub fn get_fields(&self) -> &[IRTypeId] {
         &self.fields
+    }
+
+    pub fn name(&self) -> Option<SymbolPointer> {
+        self.name
     }
 }


### PR DESCRIPTION
## Summary

This PR improves the ir visualizer, by implementing some inlinings and structs and components. As well as typings

## Scope

- Added formatting types, components, and struct
- Inlined code

## Validation

```bash
# example
cargo test
cargo fmt --all -- --check
cargo clippy --all-targets --all-features -- -D warnings
```

## Documentation Impact

- [x] No documentation changes were needed
- [ ] I updated the relevant documentation

## Checklist

- [x] My change is focused and reviewable
- [x] I performed a self-review
- [x] I added comments only where they help explain non-obvious logic
- [x] I added or updated tests when applicable
- [x] I ran the validation listed above
- [x] I used the existing issue/PR templates where applicable

## Related Issues

Closes N/A
