### PR TITLE
Refactor/context symbols

### DIFF
--- a/crates/common/src/symbols.rs
+++ b/crates/common/src/symbols.rs
@@ -3,11 +3,11 @@ use std::{hash::Hash, marker::PhantomData};
 use rart::{AdaptiveRadixTree, VectorKey};
 ///A pointer to some intern string. This is 48bits for the actual position of the string in the internalized string, and 16bits for it's length
 #[derive(Debug)]
-pub struct SymbolPointer<T>(usize, PhantomData<T>);
+pub struct SymbolPointer<T>(u64, PhantomData<T>);
 
 impl<T> SymbolPointer<T> {
-    pub fn new(ptr: usize, length: u16) -> Self {
-        Self(ptr << 16 | length as usize, PhantomData)
+    pub fn new(ptr: u64, length: u16) -> Self {
+        Self(ptr << 16 | length as u64, PhantomData)
     }
 }
 
@@ -42,7 +42,7 @@ pub struct InternalizedString {
 impl InternalizedString {
     ///Inserts the provided `s` string and returns it's pointer. Note that it's size cannot be >65535
     pub fn insert<T>(&mut self, s: &str) -> SymbolPointer<T> {
-        let ptr = self.inner.len();
+        let ptr = self.inner.len() as u64;
         let size = s.len();
         self.inner.extend_from_slice(s.as_bytes());
         SymbolPointer::new(ptr, size as u16)
@@ -64,8 +64,8 @@ impl<Ctx> std::default::Default for SymbolsModule<Ctx> {
 impl<Ctx> std::ops::Index<SymbolPointer<Ctx>> for SymbolsModule<Ctx> {
     type Output = str;
     fn index(&self, ptr: SymbolPointer<Ctx>) -> &Self::Output {
-        let size = ptr.0 & 0xffff;
-        let ptr = ptr.0 >> 16;
+        let size = ptr.0 as usize & 0xffff;
+        let ptr = ptr.0 as usize >> 16;
         unsafe { std::str::from_utf8_unchecked(&self.names.inner[ptr..ptr + size]) }
     }
 }

--- a/crates/common/src/symbols.rs
+++ b/crates/common/src/symbols.rs
@@ -1,13 +1,37 @@
+use std::{hash::Hash, marker::PhantomData};
+
 use rart::{AdaptiveRadixTree, VectorKey};
 ///A pointer to some intern string. This is 48bits for the actual position of the string in the internalized string, and 16bits for it's length
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub struct SymbolPointer(usize);
+#[derive(Debug)]
+pub struct SymbolPointer<T>(usize, PhantomData<T>);
 
-impl SymbolPointer {
+impl<T> SymbolPointer<T> {
     pub fn new(ptr: usize, length: u16) -> Self {
-        Self(ptr << 16 | length as usize)
+        Self(ptr << 16 | length as usize, PhantomData)
     }
 }
+
+impl<T> Clone for SymbolPointer<T> {
+    fn clone(&self) -> Self {
+        Self(self.0, self.1)
+    }
+}
+
+impl<T> Copy for SymbolPointer<T> {}
+
+impl<T> PartialEq for SymbolPointer<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+impl<T> Eq for SymbolPointer<T> {}
+
+impl<T> Hash for SymbolPointer<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
 ///A internalized string is an wrapper over strings to don't allocate too much on the heap.
 ///The inner string might look something like `CONTENTCONTENT2CONTENT3`, where `CONTENT`, `CONTENT2` and `CONTENT3` are the actual string inserted
 #[derive(Debug, Default)]
@@ -17,7 +41,7 @@ pub struct InternalizedString {
 
 impl InternalizedString {
     ///Inserts the provided `s` string and returns it's pointer. Note that it's size cannot be >65535
-    pub fn insert(&mut self, s: &str) -> SymbolPointer {
+    pub fn insert<T>(&mut self, s: &str) -> SymbolPointer<T> {
         let ptr = self.inner.len();
         let size = s.len();
         self.inner.extend_from_slice(s.as_bytes());
@@ -26,34 +50,34 @@ impl InternalizedString {
 }
 
 ///The structure that will be responsible to intern names inside the HIR. It will map a string S to it's symbol
-pub struct SymbolsModule {
+pub struct SymbolsModule<Ctx> {
     names: InternalizedString,
-    name_mapping: AdaptiveRadixTree<VectorKey, SymbolPointer>,
+    name_mapping: AdaptiveRadixTree<VectorKey, SymbolPointer<Ctx>>,
 }
 
-impl std::default::Default for SymbolsModule {
+impl<Ctx> std::default::Default for SymbolsModule<Ctx> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::ops::Index<SymbolPointer> for SymbolsModule {
+impl<Ctx> std::ops::Index<SymbolPointer<Ctx>> for SymbolsModule<Ctx> {
     type Output = str;
-    fn index(&self, ptr: SymbolPointer) -> &Self::Output {
+    fn index(&self, ptr: SymbolPointer<Ctx>) -> &Self::Output {
         let size = ptr.0 & 0xffff;
         let ptr = ptr.0 >> 16;
         unsafe { std::str::from_utf8_unchecked(&self.names.inner[ptr..ptr + size]) }
     }
 }
 
-impl SymbolsModule {
+impl<Ctx> SymbolsModule<Ctx> {
     pub fn new() -> Self {
         Self {
             names: InternalizedString::default(),
             name_mapping: AdaptiveRadixTree::new(),
         }
     }
-    pub fn intern(&mut self, s: &str) -> SymbolPointer {
+    pub fn intern(&mut self, s: &str) -> SymbolPointer<Ctx> {
         if let Some(ptr) = self.name_mapping.get(s) {
             *ptr
         } else {
@@ -63,16 +87,16 @@ impl SymbolsModule {
         }
     }
     ///Retrieves the pointer of the string on this module.
-    pub fn retrieve(&self, s: &str) -> Option<&SymbolPointer> {
+    pub fn retrieve(&self, s: &str) -> Option<&SymbolPointer<Ctx>> {
         self.name_mapping.get(s)
     }
 
-    pub fn get_name(&self, ptr: SymbolPointer) -> &str {
+    pub fn get_name(&self, ptr: SymbolPointer<Ctx>) -> &str {
         &self[ptr]
     }
 }
 
-impl std::fmt::Debug for SymbolsModule {
+impl<Ctx> std::fmt::Debug for SymbolsModule<Ctx> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let result = f
             .debug_struct("SymbolsModule")

--- a/crates/hir/src/error.rs
+++ b/crates/hir/src/error.rs
@@ -1,6 +1,9 @@
-use crate::model::{HirExpression, HirType};
+use crate::{
+    SymbolPointer,
+    model::{HirExpression, HirType},
+};
 
-use common::{Span, SymbolPointer};
+use common::Span;
 
 /// An error produced during HIR generation or type checking.
 ///

--- a/crates/hir/src/expression.rs
+++ b/crates/hir/src/expression.rs
@@ -1,11 +1,11 @@
 use std::mem::discriminant;
 
 use crate::{
-    ExpressionId, Result, SlynxHir, TypeId,
+    ExpressionId, Result, SlynxHir, SymbolPointer, TypeId,
     error::{HIRError, HIRErrorKind},
     model::{FieldMethod, HirExpression, HirExpressionKind, HirStatementKind, HirType},
 };
-use common::{Operator, Span, SymbolPointer};
+use common::{Operator, Span};
 use slynx_parser::{ASTExpression, ASTExpressionKind, ASTStatement, GenericIdentifier, NamedExpr};
 
 impl SlynxHir {

--- a/crates/hir/src/helpers/expressions.rs
+++ b/crates/hir/src/helpers/expressions.rs
@@ -1,8 +1,8 @@
 use crate::{
-    ExpressionId, HirComponentExpression, SlynxHir, TypeId, VariableId,
+    ExpressionId, HirComponentExpression, SlynxHir, SymbolPointer, TypeId, VariableId,
     model::{HirExpression, HirExpressionKind, HirStatement},
 };
-use common::{Operator, Span, SymbolPointer};
+use common::{Operator, Span};
 
 impl SlynxHir {
     /// Creates a tuple expression with the given type and values.

--- a/crates/hir/src/helpers/names.rs
+++ b/crates/hir/src/helpers/names.rs
@@ -1,6 +1,6 @@
-use common::{Span, SymbolPointer};
+use common::Span;
 
-use crate::{HIRError, Result, SlynxHir, VariableId};
+use crate::{HIRError, Result, SlynxHir, SymbolPointer, VariableId};
 
 impl SlynxHir {
     ///Tries to retrieve a variable with the provided `name` on the current active scope

--- a/crates/hir/src/helpers/types.rs
+++ b/crates/hir/src/helpers/types.rs
@@ -1,6 +1,4 @@
-use common::SymbolPointer;
-
-use crate::{SlynxHir, TypeId, VariableId, model::HirType};
+use crate::{SlynxHir, SymbolPointer, TypeId, VariableId, model::HirType};
 
 impl SlynxHir {
     /// Retrieves the id of the `infer` type.

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -97,6 +97,7 @@ pub use model::*;
 /// This is the standard result type used throughout the HIR module, wrapping
 /// successful values or [`HIRError`] instances with detailed diagnostic information.
 pub type Result<T> = std::result::Result<T, HIRError>;
+pub type SymbolPointer = common::SymbolPointer<SlynxHir>;
 
 /// The main HIR structure coordinating high-level intermediate representation.
 ///

--- a/crates/hir/src/model/declarations.rs
+++ b/crates/hir/src/model/declarations.rs
@@ -23,10 +23,10 @@
 //! - [`HirDeclarationKind`] — Enum of declaration kinds
 //! - [`ComponentMemberDeclaration`] — Members of a component declaration
 
-use common::{Span, SymbolPointer};
+use common::Span;
 
 use crate::{
-    DeclarationId, PropertyId, TypeId, VariableId,
+    DeclarationId, PropertyId, SymbolPointer, TypeId, VariableId,
     model::{
         HirComponentExpression, HirExpression, HirStatement, HirStyleStatement, PropertyExpression,
     },

--- a/crates/hir/src/model/expression.rs
+++ b/crates/hir/src/model/expression.rs
@@ -85,10 +85,10 @@
 //! - [`crate::hir::implementation::expression::resolve_expr`] — Expression resolution
 
 use crate::{
-    DeclarationId, ExpressionId, TypeId, VariableId,
+    DeclarationId, ExpressionId, SymbolPointer, TypeId, VariableId,
     model::{HirStatement, HirStyleUsage},
 };
-use common::{Operator, Span, SymbolPointer};
+use common::{Operator, Span};
 
 /// A property assignment within a component construction expression.
 ///

--- a/crates/hir/src/model/statements.rs
+++ b/crates/hir/src/model/statements.rs
@@ -76,9 +76,9 @@
 //!
 //! During HIR generation, this expression is wrapped in a [`Return`] statement.
 
-use common::{Span, SymbolPointer};
+use common::Span;
 
-use crate::{TypeId, VariableId, model::HirExpression};
+use crate::{SymbolPointer, TypeId, VariableId, model::HirExpression};
 
 #[derive(Debug)]
 ///A Style definition when declaring a stylesheet

--- a/crates/hir/src/model/types.rs
+++ b/crates/hir/src/model/types.rs
@@ -52,8 +52,8 @@
 //! - [`crate::hir::TypeId`] — Type identifiers
 //! - [`crate::hir::modules::TypesModule`] — Type management
 
-use crate::{TypeId, VariableId};
-use common::SymbolPointer;
+use crate::{SymbolPointer, TypeId, VariableId};
+
 use slynx_parser::VisibilityModifier;
 
 /// A method for accessing fields on types.

--- a/crates/hir/src/modules/declarations.rs
+++ b/crates/hir/src/modules/declarations.rs
@@ -1,6 +1,4 @@
-use common::SymbolPointer;
-
-use crate::{DeclarationId, TypeId};
+use crate::{DeclarationId, SymbolPointer, TypeId};
 use std::collections::HashMap;
 
 /// A top level module that keeps track of all the declarations on the Hir.

--- a/crates/hir/src/modules/mod.rs
+++ b/crates/hir/src/modules/mod.rs
@@ -1,5 +1,7 @@
-use crate::{DeclarationId, Result, TypeId, VariableId, error::HIRError, model::HirType};
-use common::Span;
+use crate::{
+    DeclarationId, Result, SymbolPointer, TypeId, VariableId, error::HIRError, model::HirType,
+};
+use common::{Span, SymbolsModule};
 use slynx_parser::ObjectField;
 
 mod declarations;

--- a/crates/hir/src/modules/scopes.rs
+++ b/crates/hir/src/modules/scopes.rs
@@ -3,9 +3,7 @@ use std::{
     ops::{Deref, DerefMut, Index, IndexMut},
 };
 
-use common::SymbolPointer;
-
-use crate::VariableId;
+use crate::{SymbolPointer, VariableId};
 
 /// A single lexical scope that maps symbol names to variable IDs.
 #[derive(Debug)]

--- a/crates/hir/src/modules/symbols.rs
+++ b/crates/hir/src/modules/symbols.rs
@@ -3,20 +3,20 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-pub use common::symbols::*;
+use common::SymbolsModule;
 
-use crate::VariableId;
+use crate::{SlynxHir, SymbolPointer, VariableId};
 
 /// Wraps a [`SymbolsModule`] and additionally tracks the source-level symbol for each variable.
 #[derive(Debug, Default)]
 pub struct SymbolsResolver {
-    module: SymbolsModule,
+    module: SymbolsModule<SlynxHir>,
     /// Tracks the original source-level symbol for each variable id.
     variable_names: HashMap<VariableId, SymbolPointer>,
 }
 
 impl Deref for SymbolsResolver {
-    type Target = SymbolsModule;
+    type Target = SymbolsModule<SlynxHir>;
     fn deref(&self) -> &Self::Target {
         &self.module
     }
@@ -29,7 +29,7 @@ impl DerefMut for SymbolsResolver {
 
 impl SymbolsResolver {
     /// Creates a new [`SymbolsResolver`] wrapping the given [`SymbolsModule`].
-    pub fn new(module: SymbolsModule) -> Self {
+    pub fn new(module: SymbolsModule<SlynxHir>) -> Self {
         Self {
             module,
             variable_names: HashMap::new(),
@@ -46,11 +46,11 @@ impl SymbolsResolver {
         &self.variable_names
     }
     /// Returns a reference to the underlying [`SymbolsModule`].
-    pub fn symbols_module(&self) -> &SymbolsModule {
+    pub fn symbols_module(&self) -> &SymbolsModule<SlynxHir> {
         &self.module
     }
     /// Consumes this resolver and returns the underlying [`SymbolsModule`].
-    pub fn get_symbols_module(self) -> SymbolsModule {
+    pub fn get_symbols_module(self) -> SymbolsModule<SlynxHir> {
         self.module
     }
 }

--- a/crates/hir/src/modules/types.rs
+++ b/crates/hir/src/modules/types.rs
@@ -1,6 +1,4 @@
-use common::SymbolPointer;
-
-use crate::{TypeId, VariableId, model::HirType};
+use crate::{SymbolPointer, TypeId, VariableId, model::HirType};
 use std::collections::HashMap;
 
 const INT_IDX: usize = 0;

--- a/crates/hir/src/names.rs
+++ b/crates/hir/src/names.rs
@@ -1,6 +1,6 @@
-use crate::{Result, SlynxHir, TypeId, VariableId};
+use crate::{Result, SlynxHir, SymbolPointer, TypeId, VariableId};
 
-use common::{Span, SymbolPointer};
+use common::Span;
 //file specific to implement things related to name resolution
 impl SlynxHir {
     pub fn intern_name(&mut self, name: &str) -> SymbolPointer {

--- a/crates/hir/src/queries.rs
+++ b/crates/hir/src/queries.rs
@@ -1,6 +1,6 @@
-use common::{Span, SymbolPointer};
+use common::Span;
 
-use crate::{DeclarationId, HIRError, HirType, Result, SlynxHir, TypeId};
+use crate::{DeclarationId, HIRError, HirType, Result, SlynxHir, SymbolPointer, TypeId};
 
 impl SlynxHir {
     ///Gets the HIR type of the given `ty`

--- a/docs/contributing/string-interning.md
+++ b/docs/contributing/string-interning.md
@@ -1,0 +1,40 @@
+# String Interning
+
+A way to make it easier to check for strings is by interning them. The interning means that we get a string such as 'maria e jose' and store it somewhere, back, we got its ID. The idea is to make its ID small and fast to copy.
+
+This is made mainly because, if we got a bunch of checks for the names instead of checking if S == 'maria e jose', which checks about 12 bytes(according to utf8 which is what rust relies on), we simply check for the ID. This is much better because of mainly 2 reasons: 
+  1. The size is always fixed(in the case of this language, 8 bytes per ID), and so it is easier for the compiler to compare, since it's a u64 internally.
+  2. Prevents heap allocation, so no mallocs and heap indirections are required.
+
+The internalizer struct of this language can be found at crates/common/src/symbols.rs.
+
+## How it works 
+Internally the ID of a string is just an encoded pointer to it. You can see so by checking that SymbolPointer is just a wrapper over u64.
+
+On the implementation, we can se a bit of magic such as `ptr << 16 | length`. What happens is that the string we are interning gets pushed to the internal string pool, and so on interning 'maria', appends 'maria' into the string pool and on interning 'jose' the same, which makes the string pool become something like 'mariajose' due to sequential appends of the strings. The main idea then is that the first 16 bits of it are the length of the string and the 48 higher bits are where it is located at. The flow of it might be such as like the following:
+
+StringPool = []
+intern("maria")
+StringPool = ["m","a","r","i","a"]
+MariaPtr = 5
+
+The reason is that 'maria' starts at the 0 index, so, the 48 higher bits are '0', and the length of 'maria' is 5, so the 16 lower bits are '5'. So the result is:
+Higher 48 Bits: 0
+Lower 16 Bits: 5
+
+StringPool = ["m","a","r","i","a"]
+intern("jose")
+StringPool = ["m","a","r","i","a", "j","o", "s", "e"]
+JosePtr = 5 << 16 | 4, or 327684
+
+The reason why 'jose' id is 327684, is because 5 << 16 is 327680, which represent that, the 48 higher bits of the number are '000..101', and the '4' comes from the '| length' where the length of 'jose' is 4, so 0 | 4 = 4.
+
+### Limits
+This limits the internal string pool to have about 281 trillion of bytes, so.. yeah, i dont think a project will use that much of strings. 
+But a more possible limitation is that due to so, strings must be at max 65kb. The main idea for so its because I really dont think anyone will write raw 65kb of content on a slynx file.
+
+## Why a Phantom?
+
+The phantom on the SymbolPointer is because both IR and HIR need to make interning but they cannot use the other's symbols pointer. The reason for so its because the IR must be agnostic from the HIR, so it needs to remake the interning. 
+
+Then the phantom is used to tell who one is creating it at the moment and not mix with the one's of another


### PR DESCRIPTION
## Summary

This PR modifies the symbol interning on the language to have contexts(a simple generic) to evict HIR and IR to use incorrect pointers

## Scope

- Only the Symbol pointer definition and HIR symbol pointer type

## Validation

List the commands, tests, or manual checks you ran.

```bash
# example
make check
```

## Documentation Impact

- [ ] No documentation changes were needed
- [x] I updated the relevant documentation

## Checklist

- [ ] My change is focused and reviewable
- [ ] I performed a self-review
- [ ] I added comments only where they help explain non-obvious logic
- [ ] I added or updated tests when applicable
- [ ] I ran the validation listed above
- [ ] I used the existing issue/PR templates where applicable

## Related Issues

Closes #N/A
