### PR TITLE
[FEATURE] Arrays and vectors implementation

### DIFF
--- a/crates/codegen/src/expressions.rs
+++ b/crates/codegen/src/expressions.rs
@@ -5,7 +5,7 @@ use slynx_hir::{
     id::{AnyDeclarationId, AnyLocalDeclarationId},
 };
 use slynx_ir::{IRPointer, IRStorage, IRType, IRTypeId, Label, Opcode, Operand, Value};
-use smallvec::SmallVec;
+use smallvec::{SmallVec, smallvec};
 
 use crate::{Codegen, CodegenError, TypeId, functions::FunctionContext};
 
@@ -203,6 +203,13 @@ impl Codegen {
         let expression = &hir[expr.data];
 
         let value = match &expression.kind {
+            HirExpressionKind::ArrayIndex(arr, index) => {
+                let index = self.lower_expression(*index, hir, context)?;
+                let arr_type = hir.view(expr.data).ty();
+                let arr = self.lower_expression(*arr, hir, context)?;
+                let ty = self.get_or_create_ir_type(&arr_type, hir, context.ir())?;
+                context.emit(Opcode::ArrayGet, smallvec![arr, index], ty)
+            }
             HirExpressionKind::Array(arr) => {
                 let view_type = hir.view(expression.ty);
                 let values = arr

--- a/crates/codegen/src/expressions.rs
+++ b/crates/codegen/src/expressions.rs
@@ -1,6 +1,6 @@
 use common::{Operator, Spanned, pool::PoolId};
 use slynx_hir::{
-    DeclarationId, HirExpression, HirExpressionKind, HirFunctionDeclaration, HirStatement,
+    DeclarationId, HirExpression, HirExpressionKind, HirFunctionDeclaration, HirStatement, HirType,
     SlynxHir, SymbolPointer,
     id::{AnyDeclarationId, AnyLocalDeclarationId},
 };
@@ -203,6 +203,24 @@ impl Codegen {
         let expression = &hir[expr.data];
 
         let value = match &expression.kind {
+            HirExpressionKind::Array(arr) => {
+                let view_type = hir.view(expression.ty);
+                let values = arr
+                    .iter()
+                    .map(|expr| self.lower_expression(*expr, hir, context))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let value_type = self.get_or_create_ir_type(&expression.ty, hir, context.ir())?;
+                match view_type.raw() {
+                    HirType::Array(ty, s) => context.emit(Opcode::Array, values, value_type),
+                    HirType::Vector(ty) => context.emit(Opcode::Vector, values, value_type),
+                    ty => {
+                        return Err(CodegenError::InternalError(format!(
+                            "When generating an array expression, got it with type '{}'. For some reason the HIR did not generate the type properly",
+                            view_type.name()
+                        )));
+                    }
+                }
+            }
             HirExpressionKind::Static { id } => {
                 if let Some(ty) = self.external_statics.get(id) {
                     let name = hir.get_name(hir.get_file(id.file_id)[id.local_id].name);

--- a/crates/codegen/src/expressions.rs
+++ b/crates/codegen/src/expressions.rs
@@ -71,6 +71,7 @@ impl Codegen {
             let IRType::Function(fid) = ctx.ir().get_type(ty) else {
                 unreachable!()
             };
+            let fid = *fid;
             ctx.ir().get_function_type(fid).get_return_type()
         };
         let mut arg_values = Vec::with_capacity(args.len());

--- a/crates/codegen/src/expressions.rs
+++ b/crates/codegen/src/expressions.rs
@@ -1,6 +1,6 @@
 use common::{Operator, Spanned, pool::PoolId};
 use slynx_hir::{
-    DeclarationId, HirExpression, HirExpressionKind, HirFunctionDeclaration, HirStatement, HirType,
+    DeclarationId, HirExpression, HirExpressionKind, HirFunctionDeclaration, HirStatement,
     SlynxHir, SymbolPointer,
     id::{AnyDeclarationId, AnyLocalDeclarationId},
 };
@@ -212,22 +212,20 @@ impl Codegen {
                 context.emit(Opcode::ArrayGet, smallvec![arr, index], ty)
             }
             HirExpressionKind::Array(arr) => {
-                let view_type = hir.view(expression.ty);
                 let values = arr
                     .iter()
                     .map(|expr| self.lower_expression(*expr, hir, context))
                     .collect::<Result<Vec<_>, _>>()?;
                 let value_type = self.get_or_create_ir_type(&expression.ty, hir, context.ir())?;
-                match view_type.raw() {
-                    HirType::Array(ty, s) => context.emit(Opcode::Array, values, value_type),
-                    HirType::Vector(ty) => context.emit(Opcode::Vector, values, value_type),
-                    ty => {
-                        return Err(CodegenError::InternalError(format!(
-                            "When generating an array expression, got it with type '{}'. For some reason the HIR did not generate the type properly",
-                            view_type.name()
-                        )));
-                    }
-                }
+                context.emit(Opcode::Array, values, value_type)
+            }
+            HirExpressionKind::Vector(vec) => {
+                let values = vec
+                    .iter()
+                    .map(|expr| self.lower_expression(*expr, hir, context))
+                    .collect::<Result<Vec<_>, _>>()?;
+                let value_type = self.get_or_create_ir_type(&expression.ty, hir, context.ir())?;
+                context.emit(Opcode::Vector, values, value_type)
             }
             HirExpressionKind::Static { id } => {
                 if let Some(ty) = self.external_statics.get(id) {

--- a/crates/codegen/src/helper/styles.rs
+++ b/crates/codegen/src/helper/styles.rs
@@ -153,7 +153,7 @@ impl Codegen {
             .flat_map(|rp| hir.flatten_type(rp.hir_type))
             .map(|prim_ty| self.get_or_create_ir_type(&prim_ty, hir, ir))
             .collect::<Result<Vec<_>, _>>()?;
-        let IRType::Struct(id) = ir.get_type(struct_ty) else {
+        let IRType::Struct(id) = ir.get_type(struct_ty).clone() else {
             unreachable!("Style struct type must be IRType::Struct");
         };
         let struct_obj = ir.get_object_type_mut(id);

--- a/crates/codegen/src/helper/styles.rs
+++ b/crates/codegen/src/helper/styles.rs
@@ -153,7 +153,7 @@ impl Codegen {
             .flat_map(|rp| hir.flatten_type(rp.hir_type))
             .map(|prim_ty| self.get_or_create_ir_type(&prim_ty, hir, ir))
             .collect::<Result<Vec<_>, _>>()?;
-        let IRType::Struct(id) = ir.get_type(struct_ty).clone() else {
+        let IRType::Struct(id) = *ir.get_type(struct_ty) else {
             unreachable!("Style struct type must be IRType::Struct");
         };
         let struct_obj = ir.get_object_type_mut(id);

--- a/crates/codegen/src/helper/types.rs
+++ b/crates/codegen/src/helper/types.rs
@@ -14,7 +14,7 @@ impl Codegen {
         let obj_handle = self
             .get_mapped_type(&decl)
             .ok_or(CodegenError::IRTypeNotRecognized(decl))?;
-        let IRType::Struct(obj) = ir.get_type(obj_handle) else {
+        let IRType::Struct(obj) = ir.get_type(obj_handle).clone() else {
             unreachable!();
         };
         let fields = if let Some(viewer) = hir.view(decl).dereference().is_struct() {

--- a/crates/codegen/src/helper/types.rs
+++ b/crates/codegen/src/helper/types.rs
@@ -14,7 +14,7 @@ impl Codegen {
         let obj_handle = self
             .get_mapped_type(&decl)
             .ok_or(CodegenError::IRTypeNotRecognized(decl))?;
-        let IRType::Struct(obj) = ir.get_type(obj_handle).clone() else {
+        let IRType::Struct(obj) = *ir.get_type(obj_handle) else {
             unreachable!();
         };
         let fields = if let Some(viewer) = hir.view(decl).dereference().is_struct() {

--- a/crates/codegen/src/queries.rs
+++ b/crates/codegen/src/queries.rs
@@ -33,6 +33,14 @@ impl Codegen {
                 };
                 ir.create_or_get_tuple(ir_fields)
             }
+            HirType::Array(t, len) => {
+                let ty = self.get_or_create_ir_type(t, hir, ir)?;
+                ir.create_array(ty, *len)
+            }
+            HirType::Vector(t) => {
+                let ty = self.get_or_create_ir_type(t, hir, ir)?;
+                ir.create_vector(ty)
+            }
 
             _ => return Err(CodegenError::IRTypeNotRecognized(*ty)),
         };

--- a/crates/hir/src/builders/component.rs
+++ b/crates/hir/src/builders/component.rs
@@ -95,7 +95,7 @@ impl<'a> HirQueueBuilder<'a> {
     ) -> Result<DeclarationId<HirComponentDeclaration>> {
         let node = self.get_node(node);
         let (owner, ty) = node.find_type(component.name)?;
-        let name = self.modules.get_type(component.name.data).identifier;
+        let name = self.modules.type_name(component.name.data);
         let id = self.hir.symbols_registry.get_or_insert_component(
             HirSymbol::new(owner, name),
             || {

--- a/crates/hir/src/builders/expression.rs
+++ b/crates/hir/src/builders/expression.rs
@@ -6,7 +6,7 @@ use common::{
 };
 use module_loader::{ASTType, ASTTypeKind, FileId};
 use slynx_parser::{
-    ASTExpression, ASTStatement, ComponentExpression, ComponentMemberValue, GenericIdentifier,
+    ASTExpression, ASTStatement, ComponentExpression, ComponentMemberValue, Type,
 };
 
 use crate::{
@@ -160,9 +160,9 @@ impl ExpressionBuilder {
     fn lookup_function(
         &self,
         queue: &HirQueueBuilder<'_>,
-        name: Spanned<DedupPoolId<GenericIdentifier>>,
+        name: Spanned<DedupPoolId<Type>>,
     ) -> Result<DeclarationId<HirFunctionDeclaration>> {
-        let identifier = queue.get_type(name.data).identifier;
+        let identifier = queue.type_name(name.data);
 
         if let Some(func) = queue
             .hir
@@ -229,7 +229,7 @@ impl ExpressionBuilder {
                 }
             }
             ASTExpression::FunctionCall { name, args } => {
-                let name_sym = queue.get_type(name.data).identifier;
+                let name_sym = queue.type_name(name.data);
                 let parent_ty = queue.hir[parent.data].ty;
                 let real_ty = queue.hir.view(parent_ty);
                 let deref = real_ty.dereference();
@@ -418,7 +418,7 @@ impl ExpressionBuilder {
                 let expected_args = func_real_type.arguments();
 
                 if expected_args.len() != args.len() {
-                    let func_name = queue.get_type(name.data).identifier;
+                    let func_name = queue.type_name(name.data);
                     return Err(HIRError::invalid_funcall_arg_length(
                         func_name,
                         expected_args.len(),
@@ -653,7 +653,7 @@ impl ExpressionBuilder {
         component: &ComponentExpression,
         span: Span,
     ) -> Result<Spanned<PoolId<HirComponentExpression>>> {
-        let name = queue.get_type(component.name.data).identifier;
+        let name = queue.type_name(component.name.data);
         let node = queue.get_node(self.file());
         let (owner, ty) = node.find_type(component.name)?;
         if queue

--- a/crates/hir/src/builders/expression.rs
+++ b/crates/hir/src/builders/expression.rs
@@ -1,13 +1,14 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Deref,
+};
 
 use common::{
     Span, Spanned, VisibilityModifier,
     pool::{DedupPoolId, PoolId},
 };
 use module_loader::{ASTType, ASTTypeKind, FileId};
-use slynx_parser::{
-    ASTExpression, ASTStatement, ComponentExpression, ComponentMemberValue, Type,
-};
+use slynx_parser::{ASTExpression, ASTStatement, ComponentExpression, ComponentMemberValue, Type};
 
 use crate::{
     DeclarationId, HIRError, HirComponentExpression, HirExpression, HirExpressionKind,
@@ -307,6 +308,99 @@ impl ExpressionBuilder {
         Ok(span.make_spanned(queue.hir.insert_expression(expr)))
     }
 
+    fn build_identifier(
+        &self,
+        queue: &HirQueueBuilder,
+        name: SymbolPointer,
+        expression_span: Span,
+    ) -> Result<HirExpression> {
+        match self.resolve_name(queue, name, expression_span)? {
+            HirName::Variable(v) => {
+                let ty = *self
+                    .variables_types
+                    .get(&v)
+                    .expect("Expected variable to have a type defined on this builder");
+                Ok(HirExpression {
+                    ty,
+                    kind: HirExpressionKind::Identifier(v),
+                })
+            }
+            HirName::Static(s) => {
+                let ty = queue.hir.get_static(s).ty;
+                Ok(HirExpression {
+                    ty,
+                    kind: HirExpressionKind::Static { id: s },
+                })
+            }
+        }
+    }
+    fn build_tuple_expression(
+        &mut self,
+        queue: &HirQueueBuilder,
+        fields: &[Spanned<DedupPoolId<ASTExpression>>],
+        expected: Option<DedupPoolId<HirType>>,
+    ) -> Result<HirExpression> {
+        let mut expressions = Vec::with_capacity(fields.len());
+        let mut types = Vec::with_capacity(fields.len());
+
+        for (idx, field) in fields.iter().enumerate() {
+            let field_type = if let Some(expected) = expected
+                && let Some(tuple) = queue.hir.view(expected).is_tuple()
+            {
+                Some(tuple.fields()[idx])
+            } else {
+                None
+            };
+            let expr = self.build_expression(queue, *field, field_type)?;
+            types.push(queue.hir[expr.data].ty);
+            expressions.push(expr);
+        }
+        Ok(HirExpression {
+            ty: queue.hir.create_tuple_type(types),
+            kind: HirExpressionKind::Tuple(expressions),
+        })
+    }
+
+    fn build_tuple_access(
+        &mut self,
+        queue: &HirQueueBuilder,
+        tuple: Spanned<DedupPoolId<ASTExpression>>,
+        expected: Option<DedupPoolId<HirType>>,
+        span: Span,
+        index: usize,
+    ) -> Result<HirExpression> {
+        let expr = self.build_expression(queue, tuple, expected)?;
+        let raw_expr = &queue.hir[expr.data];
+        let parent_view = queue.hir.view(raw_expr.ty);
+        let resolved = parent_view.dereference();
+        let ty = match resolved.is_tuple() {
+            None => {
+                let ty = (*resolved).clone();
+                return Err(HIRError::not_a_tuple(ty, span));
+            }
+            Some(tuple_view) => {
+                let field_index = index;
+                let fields = tuple_view.fields();
+                if field_index >= fields.len() {
+                    return Err(HIRError::invalid_tuple_index(
+                        field_index,
+                        fields.len(),
+                        span,
+                    ));
+                }
+                fields[field_index]
+            }
+        };
+        Ok(HirExpression {
+            ty,
+            kind: HirExpressionKind::FieldAccess {
+                expr,
+                field_index: index,
+                field_name: None,
+            },
+        })
+    }
+
     #[allow(clippy::only_used_in_recursion)]
     pub(crate) fn build_expression(
         &mut self,
@@ -325,79 +419,19 @@ impl ExpressionBuilder {
                 kind: HirExpressionKind::True,
             },
             ASTExpression::Identifier(name) => {
-                match self.resolve_name(queue, *name, expression.span)? {
-                    HirName::Variable(v) => {
-                        let ty = *self
-                            .variables_types
-                            .get(&v)
-                            .expect("Expected variable to have a type defined on this builder");
-                        HirExpression {
-                            ty,
-                            kind: HirExpressionKind::Identifier(v),
-                        }
-                    }
-                    HirName::Static(s) => {
-                        let ty = queue.hir.get_static(s).ty;
-                        HirExpression {
-                            ty,
-                            kind: HirExpressionKind::Static { id: s },
-                        }
-                    }
-                }
+                self.build_identifier(queue, *name, expression.span)?
             }
-            ASTExpression::IntLiteral(i) => queue.hir.create_int_expression(*i, 0), /*if let Some(expected) = expected {
-            queue.hir.create_int_expression(*i, 0)
-            }else {}*/
+            ASTExpression::IntLiteral(i) => queue.hir.create_int_expression(*i, 0),
             ASTExpression::FloatLiteral(f) => queue.hir.create_float_expression(f.into_inner()),
             ASTExpression::StringLiteral(s) => queue.hir.create_strliteral_expression(*s),
-            ASTExpression::Tuple(fields) => {
-                let mut expressions = Vec::with_capacity(fields.len());
-                let mut types = Vec::with_capacity(fields.len());
-                for field in fields {
-                    let expr = self.build_expression(queue, *field, expected)?;
-                    types.push(queue.hir[expr.data].ty);
-                    expressions.push(expr);
-                }
-                HirExpression {
-                    ty: queue.hir.create_tuple_type(types),
-                    kind: HirExpressionKind::Tuple(expressions),
-                }
-            }
+            ASTExpression::Tuple(fields) => self.build_tuple_expression(queue, fields, expected)?,
+
             ASTExpression::FieldAccess { parent, field } => {
                 let parent = self.build_expression(queue, *parent, expected)?;
                 return self.build_field_access(queue, parent, *field, expression.span);
             }
             ASTExpression::TupleAccess { tuple, index } => {
-                let expr = self.build_expression(queue, *tuple, expected)?;
-                let raw_expr = &queue.hir[expr.data];
-                let parent_view = queue.hir.view(raw_expr.ty);
-                let resolved = parent_view.dereference();
-                let ty = match resolved.is_tuple() {
-                    None => {
-                        let ty = (*resolved).clone();
-                        return Err(HIRError::not_a_tuple(ty, expression.span));
-                    }
-                    Some(tuple_view) => {
-                        let field_index = *index as usize;
-                        let fields = tuple_view.fields();
-                        if field_index >= fields.len() {
-                            return Err(HIRError::invalid_tuple_index(
-                                field_index,
-                                fields.len(),
-                                expression.span,
-                            ));
-                        }
-                        fields[field_index]
-                    }
-                };
-                HirExpression {
-                    ty,
-                    kind: HirExpressionKind::FieldAccess {
-                        expr,
-                        field_index: *index as usize,
-                        field_name: None,
-                    },
-                }
+                self.build_tuple_access(queue, *tuple, expected, expression.span, *index as usize)?
             }
             ASTExpression::Binary { lhs, op, rhs } => {
                 let lhs = self.build_expression(queue, *lhs, expected)?;
@@ -559,6 +593,57 @@ impl ExpressionBuilder {
                 HirExpression {
                     ty,
                     kind: HirExpressionKind::Object { name: ty, fields },
+                }
+            }
+            ASTExpression::Array(expressions) => {
+                let mut exprs = Vec::with_capacity(expressions.len());
+                let Some(first) = expressions.first() else {
+                    return if let Some(ty) = expected {
+                        let expr = queue.hir.insert_expression(HirExpression {
+                            ty: ty,
+                            kind: HirExpressionKind::Array(exprs),
+                        });
+                        Ok(expression.span.make_spanned(expr))
+                    } else {
+                        Err(HIRError::couldnt_infer(expression.span))
+                    };
+                };
+                let (inner_type, real_type) = {
+                    match () {
+                        _ if let Some((ty, size)) =
+                            expected.and_then(|expected| queue.hir.view(expected).is_array()) =>
+                        {
+                            (
+                                Some(ty),
+                                Some(queue.hir.create_type(HirType::Array(ty, size))),
+                            )
+                        }
+                        _ if let Some(HirType::Vector(ty)) =
+                            expected.map(|ty| &queue.hir.deref()[ty]) =>
+                        {
+                            (Some(*ty), Some(queue.hir.create_type(HirType::Vector(*ty))))
+                        }
+                        () => (None, expected),
+                    }
+                };
+                let expr = self.build_expression(queue, *first, inner_type)?;
+                let ty = queue.hir[expr.data].ty;
+                if let Some(expected) = inner_type {
+                    self.unify_types(queue, ty, expected, expression.span)?;
+                }
+                exprs.push(expr);
+                for expr in &expressions[1..] {
+                    let expr = self.build_expression(queue, *expr, Some(ty))?;
+                    exprs.push(expr);
+                }
+                let final_type = if let Some(ty) = real_type {
+                    ty
+                } else {
+                    queue.hir.create_type(HirType::Vector(ty))
+                };
+                HirExpression {
+                    ty: final_type,
+                    kind: HirExpressionKind::Array(exprs),
                 }
             }
         };

--- a/crates/hir/src/builders/expression.rs
+++ b/crates/hir/src/builders/expression.rs
@@ -120,14 +120,17 @@ impl ExpressionBuilder {
             queue.hir.view(expected).dereference(),
         ) {
             (a, b) if *a == *b => Ok(a.data),
-            (received, _) => {
-                let name = queue.hir.intern_name(&format!("{:?}", *received));
-                Err(HIRError::invalid_type(
-                    name,
-                    InvalidTypeReason::IncorrectUsage,
-                    span,
-                ))
+            (received, expected)
+                if received.is_vector().is_some()
+                    && let Some((inner, size)) = expected.is_array() =>
+            {
+                Ok(queue.hir.create_type(HirType::Array(inner, size)))
             }
+            (received, expected) => Err(HIRError::unexpected_type(
+                received.data,
+                expected.data,
+                span,
+            )),
         }
     }
 
@@ -442,7 +445,7 @@ impl ExpressionBuilder {
                             ty: after_index_type,
                         }
                     }
-                    _ => unimplemented!("Ranges are not implemented yet"),
+                    r => unimplemented!("Ranges {r:?} are not implemented yet"),
                 }
             }
             ASTExpression::False => HirExpression {
@@ -633,14 +636,15 @@ impl ExpressionBuilder {
             ASTExpression::Array(expressions) => {
                 let mut exprs = Vec::with_capacity(expressions.len());
                 let Some(first) = expressions.first() else {
-                    return if let Some(ty) = expected {
-                        let expr = queue.hir.insert_expression(HirExpression {
-                            ty: ty,
-                            kind: HirExpressionKind::Array(exprs),
-                        });
-                        Ok(expression.span.make_spanned(expr))
-                    } else {
-                        Err(HIRError::couldnt_infer(expression.span))
+                    return match expected {
+                        Some(ty) if queue.hir.view(ty).is_vector().is_some() => {
+                            let expr = queue.hir.insert_expression(HirExpression {
+                                ty,
+                                kind: HirExpressionKind::Array(exprs),
+                            });
+                            Ok(expression.span.make_spanned(expr))
+                        }
+                        Some(_) | None => Err(HIRError::couldnt_infer(expression.span)), //ideal is to make Some(t) => unexecpted_type(unknown.vector(), t), but i dont know if this is good enough due to adding a type that will be used only as fallback for errors
                     };
                 };
                 let (inner_type, real_type) = {
@@ -712,7 +716,12 @@ impl ExpressionBuilder {
                 HirStatement::Expression { expr }
             }
             ASTStatement::Var { name, ty, rhs } | ASTStatement::MutableVar { name, ty, rhs } => {
-                let expr = self.build_expression(queue, *rhs, None)?;
+                let var_type = if let Some(ty) = ty {
+                    Some(queue.get_node(self.file()).find_type(*ty)?.1)
+                } else {
+                    None
+                };
+                let expr = self.build_expression(queue, *rhs, var_type)?;
                 let exprty = queue.hir.view(expr.data).ty();
                 let expected_type = if let Some(expected_ty) = ty {
                     queue.get_node(self.file()).find_type(*expected_ty)?.1

--- a/crates/hir/src/builders/expression.rs
+++ b/crates/hir/src/builders/expression.rs
@@ -8,7 +8,9 @@ use common::{
     pool::{DedupPoolId, PoolId},
 };
 use module_loader::{ASTType, ASTTypeKind, FileId};
-use slynx_parser::{ASTExpression, ASTStatement, ComponentExpression, ComponentMemberValue, Type};
+use slynx_parser::{
+    ASTExpression, ASTStatement, ComponentExpression, ComponentMemberValue, RangeType, Type,
+};
 
 use crate::{
     DeclarationId, HIRError, HirComponentExpression, HirExpression, HirExpressionKind,
@@ -401,7 +403,6 @@ impl ExpressionBuilder {
         })
     }
 
-    #[allow(clippy::only_used_in_recursion)]
     pub(crate) fn build_expression(
         &mut self,
         queue: &HirQueueBuilder<'_>,
@@ -410,6 +411,40 @@ impl ExpressionBuilder {
     ) -> Result<Spanned<PoolId<HirExpression>>> {
         let expr = queue.get_expr(expression.data);
         let expr = match expr {
+            ASTExpression::IndexExpression(expr, range) => {
+                let expr = self.build_expression(queue, *expr, expected)?;
+                let after_index_type = {
+                    let expr_type = queue.hir[expr.data].ty;
+                    let actual_type = queue.hir.deref()[expr_type].clone();
+                    match actual_type {
+                        HirType::Vector(t) => t,
+                        HirType::Array(t, _) => t,
+                        _ => return Err(HIRError::invalid_indexing(expression.span)),
+                    }
+                };
+                match range {
+                    RangeType::NoRange(index) => {
+                        let index = self.build_expression(queue, *index, expected)?;
+                        let viewer = queue.hir.view(index.data);
+                        let ty_viewer = viewer.ty_viewer();
+                        match ty_viewer.raw() {
+                            HirType::Int => {}
+                            _ => {
+                                return Err(HIRError::unexpected_type(
+                                    ty_viewer.data,
+                                    queue.hir.create_type(HirType::Int),
+                                    index.span,
+                                ));
+                            }
+                        }
+                        HirExpression {
+                            kind: HirExpressionKind::ArrayIndex(expr, index),
+                            ty: after_index_type,
+                        }
+                    }
+                    _ => unimplemented!("Ranges are not implemented yet"),
+                }
+            }
             ASTExpression::False => HirExpression {
                 ty: queue.hir.create_type(HirType::Bool),
                 kind: HirExpressionKind::False,

--- a/crates/hir/src/builders/expression.rs
+++ b/crates/hir/src/builders/expression.rs
@@ -16,7 +16,7 @@ use crate::{
     DeclarationId, HIRError, HirComponentExpression, HirExpression, HirExpressionKind,
     HirFunctionDeclaration, HirStatement, HirStaticDeclaration, HirType, PropertyExpression,
     Result, SymbolPointer, VariableId, builders::HirQueueBuilder, context::HirSymbol,
-    error::InvalidTypeReason, helpers::Visible, id::OwnerId,
+    helpers::Visible, id::OwnerId,
 };
 
 /// Result of building a body with the ExpressionBuilder.

--- a/crates/hir/src/builders/expression.rs
+++ b/crates/hir/src/builders/expression.rs
@@ -120,12 +120,6 @@ impl ExpressionBuilder {
             queue.hir.view(expected).dereference(),
         ) {
             (a, b) if *a == *b => Ok(a.data),
-            (received, expected)
-                if received.is_vector().is_some()
-                    && let Some((inner, size)) = expected.is_array() =>
-            {
-                Ok(queue.hir.create_type(HirType::Array(inner, size)))
-            }
             (received, expected) => Err(HIRError::unexpected_type(
                 received.data,
                 expected.data,
@@ -637,34 +631,25 @@ impl ExpressionBuilder {
                 let mut exprs = Vec::with_capacity(expressions.len());
                 let Some(first) = expressions.first() else {
                     return match expected {
-                        Some(ty) if queue.hir.view(ty).is_vector().is_some() => {
+                        Some(ty) if queue.hir.view(ty).is_array().is_some() => {
                             let expr = queue.hir.insert_expression(HirExpression {
                                 ty,
                                 kind: HirExpressionKind::Array(exprs),
                             });
                             Ok(expression.span.make_spanned(expr))
                         }
-                        Some(_) | None => Err(HIRError::couldnt_infer(expression.span)), //ideal is to make Some(t) => unexecpted_type(unknown.vector(), t), but i dont know if this is good enough due to adding a type that will be used only as fallback for errors
+                        Some(_) | None => Err(HIRError::couldnt_infer(expression.span)),
                     };
                 };
-                let (inner_type, real_type) = {
-                    match () {
-                        _ if let Some((ty, size)) =
-                            expected.and_then(|expected| queue.hir.view(expected).is_array()) =>
-                        {
-                            (
-                                Some(ty),
-                                Some(queue.hir.create_type(HirType::Array(ty, size))),
-                            )
-                        }
-                        _ if let Some(HirType::Vector(ty)) =
-                            expected.map(|ty| &queue.hir.deref()[ty]) =>
-                        {
-                            (Some(*ty), Some(queue.hir.create_type(HirType::Vector(*ty))))
-                        }
-                        () => (None, expected),
-                    }
-                };
+                let (inner_type, real_type) =
+                    if let Some((ty, size)) = expected.and_then(|e| queue.hir.view(e).is_array()) {
+                        (
+                            Some(ty),
+                            Some(queue.hir.create_type(HirType::Array(ty, size))),
+                        )
+                    } else {
+                        (None, None)
+                    };
                 let expr = self.build_expression(queue, *first, inner_type)?;
                 let ty = queue.hir[expr.data].ty;
                 if let Some(expected) = inner_type {
@@ -678,11 +663,42 @@ impl ExpressionBuilder {
                 let final_type = if let Some(ty) = real_type {
                     ty
                 } else {
-                    queue.hir.create_type(HirType::Vector(ty))
+                    queue.hir.create_type(HirType::Array(ty, exprs.len()))
                 };
                 HirExpression {
                     ty: final_type,
                     kind: HirExpressionKind::Array(exprs),
+                }
+            }
+            ASTExpression::Vector(expressions) => {
+                let mut exprs = Vec::with_capacity(expressions.len());
+                let Some(first) = expressions.first() else {
+                    return match expected {
+                        Some(ty) if queue.hir.view(ty).is_vector().is_some() => {
+                            let expr = queue.hir.insert_expression(HirExpression {
+                                ty,
+                                kind: HirExpressionKind::Vector(exprs),
+                            });
+                            Ok(expression.span.make_spanned(expr))
+                        }
+                        Some(_) | None => Err(HIRError::couldnt_infer(expression.span)),
+                    };
+                };
+                let inner_type = expected.and_then(|e| queue.hir.view(e).is_vector());
+                let expr = self.build_expression(queue, *first, inner_type)?;
+                let ty = queue.hir[expr.data].ty;
+                if let Some(expected) = inner_type {
+                    self.unify_types(queue, ty, expected, expression.span)?;
+                }
+                exprs.push(expr);
+                for expr in &expressions[1..] {
+                    let expr = self.build_expression(queue, *expr, Some(ty))?;
+                    exprs.push(expr);
+                }
+                let final_type = queue.hir.create_type(HirType::Vector(ty));
+                HirExpression {
+                    ty: final_type,
+                    kind: HirExpressionKind::Vector(exprs),
                 }
             }
         };

--- a/crates/hir/src/builders/function.rs
+++ b/crates/hir/src/builders/function.rs
@@ -26,7 +26,7 @@ impl<'a> HirQueueBuilder<'a> {
         f: &'a FuncDeclaration,
         node: HirNode<'_>,
     ) -> Result<DeclarationId<HirFunctionDeclaration>> {
-        let name = self.modules.get_type(f.name.data).identifier;
+        let name = self.modules.type_name(f.name.data);
         let signature = node.get_signature_of_function(f)?;
         let names = f.args.iter().map(|arg| arg.data.name).collect();
         let id = self.hir.symbols_registry.get_or_insert_function(

--- a/crates/hir/src/builders/mod.rs
+++ b/crates/hir/src/builders/mod.rs
@@ -15,8 +15,8 @@ use crossbeam_channel::select;
 use dashmap::{DashMap, DashSet};
 use module_loader::{ASTType, ASTTypeKind, FileId, Modules};
 use slynx_parser::{
-    ASTStatement, ComponentDeclaration, ComponentMemberKind, FuncDeclaration, GenericIdentifier,
-    StaticDeclaration,
+    ASTStatement, ComponentDeclaration, ComponentMemberKind, FuncDeclaration,
+    StaticDeclaration, Type,
 };
 
 use crate::{
@@ -91,13 +91,13 @@ impl HirNode<'_> {
     ///Finds the Hir type for the given `ty` and what file contains it if theres some. The given `file` is the file id where the given `ty` was generated at
     fn find_type(
         &self,
-        ty: Spanned<DedupPoolId<GenericIdentifier>>,
+        ty: Spanned<DedupPoolId<Type>>,
     ) -> Result<(FileId, DedupPoolId<HirType>)> {
         let real = self.modules.get_type(ty.data);
 
         if let Some(ty) = self
             .modules
-            .find_type_inside_module(self.entry, real.identifier)
+            .find_type_inside_module(self.entry, real.name())
         {
             let id = match ty.content {
                 ASTTypeKind::Builtin(builtin) => self.hir.create_type(builtin.into()),
@@ -105,7 +105,7 @@ impl HirNode<'_> {
                     return self.find_type(alias.target);
                 }
                 ASTTypeKind::Struct(s) => {
-                    let struct_name = self.get_type(s.name.data).identifier;
+                    let struct_name = self.type_name(s.name.data);
                     let fields = s
                         .fields
                         .iter()
@@ -142,7 +142,7 @@ impl HirNode<'_> {
             };
             Ok((ty.owner, id))
         } else {
-            Err(HIRError::type_unrecognized(real.identifier, ty.span))
+            Err(HIRError::type_unrecognized(real.name(), ty.span))
         }
     }
     ///Gets the signature of the given `f` function. Asserting the id of the file it was generated is the given `file`.
@@ -164,7 +164,7 @@ impl HirNode<'_> {
         &self,
         component: &ComponentDeclaration,
     ) -> Result<DedupPoolId<HirType>> {
-        let name = self.get_type(component.name.data).identifier;
+        let name = self.type_name(component.name.data);
         let (properties, children) = {
             let mut properties = Vec::with_capacity(component.members.len());
             let mut components = Vec::with_capacity(component.members.len());
@@ -184,7 +184,7 @@ impl HirNode<'_> {
                         if let Some(view) = view.is_component() {
                             components.push(view.data);
                         } else {
-                            let name = self.get_type(c.data.name.data).identifier;
+                            let name = self.type_name(c.data.name.data);
                             return Err(HIRError::not_a_component(name, c.span));
                         };
                     }
@@ -200,7 +200,7 @@ impl HirNode<'_> {
         &self,
         component: &ComponentDeclaration,
     ) -> Result<DedupPoolId<HirType>> {
-        let name = self.get_type(component.name.data).identifier;
+        let name = self.type_name(component.name.data);
         let key = (self.entry, name);
 
         // Push onto cycle-detection stack
@@ -367,7 +367,7 @@ impl<'a> HirQueueBuilder<'a> {
         let method = obj_decl
             .methods
             .iter()
-            .find(|m| self.modules.get_type(m.method_name.data).identifier == method_name);
+            .find(|m| self.modules.type_name(m.method_name.data) == method_name);
 
         let Some(method) = method else {
             return Ok(None);
@@ -379,7 +379,7 @@ impl<'a> HirQueueBuilder<'a> {
 
         let mut args = Vec::with_capacity(method.arguments.len());
         for arg in &method.arguments {
-            let ty = if self.modules.get_type(arg.data.kind.data).identifier == self_sym {
+            let ty = if self.modules.type_name(arg.data.kind.data) == self_sym {
                 struct_ty
             } else {
                 let (_, ty) = node.find_type(arg.data.kind)?;
@@ -388,7 +388,7 @@ impl<'a> HirQueueBuilder<'a> {
             args.push(ty);
         }
 
-        let return_type = if self.modules.get_type(method.return_type.data).identifier == self_sym {
+        let return_type = if self.modules.type_name(method.return_type.data) == self_sym {
             struct_ty
         } else {
             let (_, ty) = node.find_type(method.return_type)?;

--- a/crates/hir/src/builders/mod.rs
+++ b/crates/hir/src/builders/mod.rs
@@ -15,7 +15,7 @@ use crossbeam_channel::select;
 use dashmap::{DashMap, DashSet};
 use module_loader::{ASTType, ASTTypeKind, FileId, Modules};
 use slynx_parser::{
-    ASTStatement, ComponentDeclaration, ComponentMemberKind, FuncDeclaration,
+    ASTExpression, ASTStatement, ComponentDeclaration, ComponentMemberKind, FuncDeclaration,
     StaticDeclaration, Type,
 };
 
@@ -89,60 +89,80 @@ pub struct HirQueueBuilder<'a> {
 
 impl HirNode<'_> {
     ///Finds the Hir type for the given `ty` and what file contains it if theres some. The given `file` is the file id where the given `ty` was generated at
-    fn find_type(
+    pub fn find_type(
         &self,
         ty: Spanned<DedupPoolId<Type>>,
     ) -> Result<(FileId, DedupPoolId<HirType>)> {
         let real = self.modules.get_type(ty.data);
+        match real {
+            Type::Plain(_) => {
+                let name = self.modules.type_name(ty.data);
+                if let Some(ty) = self.modules.find_type_inside_module(self.entry, name) {
+                    let id = match ty.content {
+                        ASTTypeKind::Builtin(builtin) => self.hir.create_type(builtin.into()),
+                        ASTTypeKind::Alias(alias) => {
+                            return self.find_type(alias.target);
+                        }
+                        ASTTypeKind::Struct(s) => {
+                            let struct_name = self.type_name(s.name.data);
+                            let fields = s
+                                .fields
+                                .iter()
+                                .map(|field| {
+                                    let field_name = field.name.data.name;
+                                    let field_ty = field.name.data.kind;
+                                    let (_, type_id) = self.find_type(field_ty)?;
 
-        if let Some(ty) = self
-            .modules
-            .find_type_inside_module(self.entry, real.name())
-        {
-            let id = match ty.content {
-                ASTTypeKind::Builtin(builtin) => self.hir.create_type(builtin.into()),
-                ASTTypeKind::Alias(alias) => {
-                    return self.find_type(alias.target);
+                                    Ok(Visible::new(field.visibility, (field_name, type_id)))
+                                })
+                                .collect::<Result<Vec<_>>>()?;
+
+                            let struct_ty =
+                                self.hir.create_struct_type(struct_name, fields, Vec::new());
+                            // Register a HirObjectDeclaration so the codegen's
+                            // hoist_declarations can create an IR struct for this type.
+                            let file = self.hir.get_or_create_file(ty.owner);
+                            let already = file
+                                .declarations
+                                .objects
+                                .iter()
+                                .any(|d| d.name == struct_name);
+                            if !already {
+                                file.create_object(HirObjectDeclaration {
+                                    name: struct_name,
+                                    ty: struct_ty,
+                                    visibility: s.visibility,
+                                    external: s.external,
+                                    attributes: Vec::new(),
+                                });
+                            }
+                            struct_ty
+                        }
+                        ASTTypeKind::Component(component) => {
+                            self.resolve_component_signature(component)?
+                        }
+                    };
+                    Ok((ty.owner, id))
+                } else {
+                    Err(HIRError::type_unrecognized(name, ty.span))
                 }
-                ASTTypeKind::Struct(s) => {
-                    let struct_name = self.type_name(s.name.data);
-                    let fields = s
-                        .fields
-                        .iter()
-                        .map(|field| {
-                            let field_name = field.name.data.name;
-                            let field_ty = field.name.data.kind;
-                            let (_, type_id) = self.find_type(field_ty)?;
-
-                            Ok(Visible::new(field.visibility, (field_name, type_id)))
-                        })
-                        .collect::<Result<Vec<_>>>()?;
-
-                    let struct_ty = self.hir.create_struct_type(struct_name, fields, Vec::new());
-                    // Register a HirObjectDeclaration so the codegen's
-                    // hoist_declarations can create an IR struct for this type.
-                    let file = self.hir.get_or_create_file(ty.owner);
-                    let already = file
-                        .declarations
-                        .objects
-                        .iter()
-                        .any(|d| d.name == struct_name);
-                    if !already {
-                        file.create_object(HirObjectDeclaration {
-                            name: struct_name,
-                            ty: struct_ty,
-                            visibility: s.visibility,
-                            external: s.external,
-                            attributes: Vec::new(),
-                        });
-                    }
-                    struct_ty
-                }
-                ASTTypeKind::Component(component) => self.resolve_component_signature(component)?,
-            };
-            Ok((ty.owner, id))
-        } else {
-            Err(HIRError::type_unrecognized(real.name(), ty.span))
+            }
+            Type::Array(t, len) => {
+                let (id, ty) = self.find_type(ty.span.make_spanned(*t))?;
+                let len = match self.modules.get_expr(*len) {
+                    ASTExpression::IntLiteral(i) => *i as usize,
+                    _ => unimplemented!(
+                        "Array length can only be used as integers at the moment. It is idealized to be used in comptime in the future"
+                    ),
+                };
+                let ty = self.hir.create_type(HirType::Array(ty, len));
+                Ok((id, ty))
+            }
+            Type::Vector(t) => {
+                let (id, ty) = self.find_type(ty.span.make_spanned(*t))?;
+                let ty = self.hir.create_type(HirType::Vector(ty));
+                Ok((id, ty))
+            }
         }
     }
     ///Gets the signature of the given `f` function. Asserting the id of the file it was generated is the given `file`.

--- a/crates/hir/src/builders/styles.rs
+++ b/crates/hir/src/builders/styles.rs
@@ -90,7 +90,7 @@ impl<'a> HirQueueBuilder<'a> {
         let style_sheet = entry
             .style()
             .iter()
-            .find(|s| self.modules.get_type(s.name.data).identifier == name)?;
+            .find(|s| self.modules.type_name(s.name.data) == name)?;
 
         self.enqueue_stylesheet(name, style_sheet, requester).ok()
     }

--- a/crates/hir/src/error.rs
+++ b/crates/hir/src/error.rs
@@ -516,7 +516,7 @@ impl std::fmt::Display for InvalidTypeReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             InvalidTypeReason::MissingGeneric => write!(f, "missing generic type"),
-            InvalidTypeReason::IncorrectUsage => write!(f, "is being used incorrectly"),
+            InvalidTypeReason::IncorrectUsage => write!(f, "being used incorrectly"),
             InvalidTypeReason::CouldntInfer => write!(f, "could not infer type"),
         }
     }

--- a/crates/hir/src/error.rs
+++ b/crates/hir/src/error.rs
@@ -31,6 +31,7 @@ pub enum InvalidWriteReason {
 /// All possible error kinds that can occur during HIR generation.
 #[derive(Debug)]
 pub enum HIRErrorKind {
+    CouldntInfer,
     NotAComponent(SymbolPointer),
     ComponentPropertyMissingType,
     ComponentNotFound(SymbolPointer),
@@ -154,6 +155,12 @@ pub enum HIRErrorKind {
 }
 
 impl HIRError {
+    pub fn couldnt_infer(span: Span) -> Self {
+        Self {
+            kind: HIRErrorKind::CouldntInfer,
+            span,
+        }
+    }
     pub fn component_not_found(name: SymbolPointer, span: Span) -> Self {
         Self {
             kind: HIRErrorKind::ComponentNotFound(name),
@@ -376,6 +383,7 @@ impl HIRError {
 impl std::fmt::Display for HIRError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.kind {
+            HIRErrorKind::CouldntInfer => write!(f, "Expression type couldn't be infered"),
             HIRErrorKind::ComponentNotFound(_) => write!(f, "Component not found"),
             HIRErrorKind::NotAComponent(_) => write!(f, "Atempt to use value as a component"),
             HIRErrorKind::ComponentPropertyMissingType => {

--- a/crates/hir/src/error.rs
+++ b/crates/hir/src/error.rs
@@ -31,6 +31,13 @@ pub enum InvalidWriteReason {
 /// All possible error kinds that can occur during HIR generation.
 #[derive(Debug)]
 pub enum HIRErrorKind {
+    UnexpectedType {
+        expected: DedupPoolId<HirType>,
+        received: DedupPoolId<HirType>,
+    },
+    ///Invalid indexing error occurs when the expression being indexed cannot be indexed. So 5[12] cannot be indexed, which then gives this error
+    InvalidIndexing,
+    ///Couldnt infer is an error when the type of something could not be inferred
     CouldntInfer,
     NotAComponent(SymbolPointer),
     ComponentPropertyMissingType,
@@ -38,6 +45,7 @@ pub enum HIRErrorKind {
 
     InvalidWrite(InvalidWriteReason),
 
+    ///An invalid field access occurs when some invalid expression is used to access a field. For example 'struct."j"' this is invalid because we cannot index things with strings since the struct layout is not runtime based
     InvalidFieldAccess,
     /// A type name was used but is not defined in the current scope.
     TypeNotRecognized(SymbolPointer),
@@ -155,6 +163,22 @@ pub enum HIRErrorKind {
 }
 
 impl HIRError {
+    pub fn invalid_indexing(span: Span) -> Self {
+        Self {
+            kind: HIRErrorKind::InvalidIndexing,
+            span,
+        }
+    }
+    pub fn unexpected_type(
+        received: DedupPoolId<HirType>,
+        expected: DedupPoolId<HirType>,
+        span: Span,
+    ) -> Self {
+        Self {
+            kind: HIRErrorKind::UnexpectedType { received, expected },
+            span,
+        }
+    }
     pub fn couldnt_infer(span: Span) -> Self {
         Self {
             kind: HIRErrorKind::CouldntInfer,
@@ -383,6 +407,13 @@ impl HIRError {
 impl std::fmt::Display for HIRError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.kind {
+            HIRErrorKind::UnexpectedType { .. } => {
+                write!(f, "Received mismatched types")
+            }
+            HIRErrorKind::InvalidIndexing => write!(
+                f,
+                "The given expression cannot be indexed because it is not an array nor vector"
+            ),
             HIRErrorKind::CouldntInfer => write!(f, "Expression type couldn't be infered"),
             HIRErrorKind::ComponentNotFound(_) => write!(f, "Component not found"),
             HIRErrorKind::NotAComponent(_) => write!(f, "Atempt to use value as a component"),

--- a/crates/hir/src/helpers/views/expressions.rs
+++ b/crates/hir/src/helpers/views/expressions.rs
@@ -6,4 +6,7 @@ impl HirViewer<'_, PoolId<HirExpression>> {
     pub fn ty(&self) -> DedupPoolId<HirType> {
         self.hir[self.data].ty
     }
+    pub fn ty_viewer(&self) -> HirViewer<'_, DedupPoolId<HirType>> {
+        self.new_with(self.ty())
+    }
 }

--- a/crates/hir/src/helpers/views/types.rs
+++ b/crates/hir/src/helpers/views/types.rs
@@ -48,7 +48,7 @@ impl HirViewer<'_, DedupPoolId<HirType>> {
         }
     }
 
-    pub fn is_vector(&self) -> Option<(DedupPoolId<HirType>)> {
+    pub fn is_vector(&self) -> Option<DedupPoolId<HirType>> {
         if let HirType::Vector(inner) = self.hir.deref()[self.data] {
             Some(inner)
         } else {

--- a/crates/hir/src/helpers/views/types.rs
+++ b/crates/hir/src/helpers/views/types.rs
@@ -48,6 +48,14 @@ impl HirViewer<'_, DedupPoolId<HirType>> {
         }
     }
 
+    pub fn is_array(&self) -> Option<(DedupPoolId<HirType>, usize)> {
+        if let HirType::Array(inner, size) = self.hir.deref()[self.data] {
+            Some((inner, size))
+        } else {
+            None
+        }
+    }
+
     pub fn is_function(&self) -> Option<HirViewer<'_, DedupPoolId<FunctionType>>> {
         if let HirType::Function(f) = self.hir.deref()[self.data] {
             Some(self.new_with(f))

--- a/crates/hir/src/helpers/views/types.rs
+++ b/crates/hir/src/helpers/views/types.rs
@@ -48,6 +48,13 @@ impl HirViewer<'_, DedupPoolId<HirType>> {
         }
     }
 
+    pub fn is_vector(&self) -> Option<(DedupPoolId<HirType>)> {
+        if let HirType::Vector(inner) = self.hir.deref()[self.data] {
+            Some(inner)
+        } else {
+            None
+        }
+    }
     pub fn is_array(&self) -> Option<(DedupPoolId<HirType>, usize)> {
         if let HirType::Array(inner, size) = self.hir.deref()[self.data] {
             Some((inner, size))

--- a/crates/hir/src/model/expression.rs
+++ b/crates/hir/src/model/expression.rs
@@ -87,6 +87,7 @@ use crate::{
     DeclarationId, HirFunctionDeclaration, HirStaticDeclaration, HirType, SymbolPointer,
     VariableId, model::HirStatement,
 };
+
 use common::{
     Operator, Spanned,
     pool::{DedupPoolId, PoolId},
@@ -555,4 +556,5 @@ pub enum HirExpressionKind {
     Static {
         id: DeclarationId<HirStaticDeclaration>,
     },
+    Array(Vec<Spanned<PoolId<HirExpression>>>),
 }

--- a/crates/hir/src/model/expression.rs
+++ b/crates/hir/src/model/expression.rs
@@ -557,4 +557,8 @@ pub enum HirExpressionKind {
         id: DeclarationId<HirStaticDeclaration>,
     },
     Array(Vec<Spanned<PoolId<HirExpression>>>),
+    ArrayIndex(
+        Spanned<PoolId<HirExpression>>,
+        Spanned<PoolId<HirExpression>>,
+    ),
 }

--- a/crates/hir/src/model/expression.rs
+++ b/crates/hir/src/model/expression.rs
@@ -557,6 +557,9 @@ pub enum HirExpressionKind {
         id: DeclarationId<HirStaticDeclaration>,
     },
     Array(Vec<Spanned<PoolId<HirExpression>>>),
+    /// A vector literal, delimited by `{` and `}` in source. Unlike [`Array`](HirExpressionKind::Array),
+    /// the size of a vector is dynamic.
+    Vector(Vec<Spanned<PoolId<HirExpression>>>),
     ArrayIndex(
         Spanned<PoolId<HirExpression>>,
         Spanned<PoolId<HirExpression>>,

--- a/crates/hir/src/model/types.rs
+++ b/crates/hir/src/model/types.rs
@@ -266,6 +266,8 @@ pub struct StyleType {
 /// - [`crate::hir::model::ComponentProperty`] — Component property definitions
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum HirType {
+    Array(DedupPoolId<HirType>, usize),
+    Vector(DedupPoolId<HirType>),
     /// A struct type with named fields.
     ///
     /// Structs are user-defined data structures with a fixed set of named fields.

--- a/crates/ir/src/api.rs
+++ b/crates/ir/src/api.rs
@@ -1,9 +1,17 @@
 use crate::{
-    Component, ComponentBuilder, ControlFlowGraph, Function, IRPointer, IRTypeId, SlynxIR,
+    Component, ComponentBuilder, ControlFlowGraph, Function, IRPointer, IRType, IRTypeId, SlynxIR,
     builder::FunctionBuilder,
 };
 
 impl SlynxIR {
+    pub fn create_vector(&self, ty: IRTypeId) -> IRTypeId {
+        self.types.insert_type(IRType::Vector(ty))
+    }
+
+    pub fn create_array(&self, ty: IRTypeId, len: usize) -> IRTypeId {
+        self.types.insert_type(IRType::Array(ty, len))
+    }
+
     pub fn create_struct(&mut self, name: &str) -> IRTypeId {
         let name = self.strings.intern(name);
         self.create_empty_struct(name).0

--- a/crates/ir/src/builder/component.rs
+++ b/crates/ir/src/builder/component.rs
@@ -115,6 +115,7 @@ impl<'a> ComponentBuilder<'a> {
             let IRType::Component(ty) = self.ir.get_type(component.ty) else {
                 unreachable!("Type of component should be, on IR, component");
             };
+            let ty = *ty;
             let ty = self.ir.get_component_type_mut(ty);
             ty.fields.extend_from_slice(&self.fields);
             ty.children.extend_from_slice(&self.children);

--- a/crates/ir/src/builder/functions.rs
+++ b/crates/ir/src/builder/functions.rs
@@ -74,6 +74,7 @@ impl<'a> FunctionBuilder<'a> {
         let IRType::Function(func_id) = self.ir.get_type(ty) else {
             unreachable!()
         };
+        let func_id = *func_id;
         let func_ty = self.ir.get_function_type_mut(func_id);
         func_ty.insert_arg_types(&args);
         func_ty.set_return_type(ret);

--- a/crates/ir/src/builder/structs.rs
+++ b/crates/ir/src/builder/structs.rs
@@ -17,9 +17,9 @@ impl<'a> StructBuilder<'a> {
         };
 
         Ok(Self {
+            ir_struct_id: *struct_id,
             ir,
             ty,
-            ir_struct_id: struct_id,
         })
     }
     pub fn insert_type(&mut self, ty: IRTypeId) {

--- a/crates/ir/src/model/instruction.rs
+++ b/crates/ir/src/model/instruction.rs
@@ -135,6 +135,8 @@ pub enum Opcode {
     GlobalExtern(SymbolPointer),
     Array,
     Vector,
+    ///Gets the array on the given index. The first operand is the value to be indexed, and the second operand is the index
+    ArrayGet,
 }
 
 // ── Instruction ────────────────────────────────────────────────────────────

--- a/crates/ir/src/model/instruction.rs
+++ b/crates/ir/src/model/instruction.rs
@@ -133,6 +133,8 @@ pub enum Opcode {
 
     Global(IRPointer<GlobalValue, 1>),
     GlobalExtern(SymbolPointer),
+    Array,
+    Vector,
 }
 
 // ── Instruction ────────────────────────────────────────────────────────────

--- a/crates/ir/src/types/irtype.rs
+++ b/crates/ir/src/types/irtype.rs
@@ -1,3 +1,5 @@
+use common::pool::DedupPoolId;
+
 use crate::{
     IRComponentId, IRSpecializedComponentType, IRStructId, types::functions::IRFunctionId,
 };
@@ -27,15 +29,6 @@ pub enum IRType {
     Component(IRComponentId),
     Struct(IRStructId),
     Function(IRFunctionId),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-///A reference to some type on the IR
-pub struct IRTypeId(pub usize);
-
-impl IRTypeId {
-    ///Creates a new `IRTypeId` from a raw usize
-    pub fn from_raw(raw: usize) -> Self {
-        IRTypeId(raw)
-    }
+    Array(DedupPoolId<IRType>, usize),
+    Vector(DedupPoolId<IRType>),
 }

--- a/crates/ir/src/types/mod.rs
+++ b/crates/ir/src/types/mod.rs
@@ -219,7 +219,6 @@ impl IRTypes {
         }
         let sid = IRStructId(self.structs.len());
         self.structs.push(s);
-        let out = self.insert_type(IRType::Struct(sid));
-        out
+        self.insert_type(IRType::Struct(sid))
     }
 }

--- a/crates/ir/src/types/mod.rs
+++ b/crates/ir/src/types/mod.rs
@@ -4,6 +4,7 @@ mod irtype;
 mod structs;
 mod tuple;
 
+use common::pool::{DedupPool, DedupPoolId};
 pub use components::*;
 pub use functions::*;
 pub use irtype::*;
@@ -32,19 +33,29 @@ pub const BUILTIN_TYPES: &[IRType] = &[
     IRType::Specialized(IRSpecializedComponentType::Div),
     IRType::Specialized(IRSpecializedComponentType::Text),
 ];
-
-#[derive(Debug, Default)]
+pub type IRTypeId = DedupPoolId<IRType>;
+#[derive(Debug)]
 pub struct IRTypes {
-    types: Vec<IRType>,
+    types: DedupPool<IRType>,
     structs: Vec<IRStruct>,
     functions: Vec<IRFunction>,
     components: Vec<IRComponent>,
 }
 
+impl std::default::Default for IRTypes {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl IRTypes {
     pub fn new() -> Self {
+        let types = DedupPool::new();
+        for builtin in BUILTIN_TYPES {
+            types.insert(*builtin);
+        }
         Self {
-            types: BUILTIN_TYPES.to_vec(),
+            types,
             structs: Vec::new(),
             functions: Vec::new(),
             components: Vec::new(),
@@ -59,23 +70,18 @@ impl IRTypes {
     }
 
     ///Checks if the provided `ty` is some variant of unsigned int
-    pub fn is_negative_int(&self, ty: IRTypeId) -> bool {
-        let index = self.usize_type().0;
-        if ty.0 == index {
-            let typ = self.types[ty.0];
-            typ == IRType::U8
-                || typ == IRType::U16
-                || typ == IRType::U32
-                || typ == IRType::U64
-                || typ == IRType::USIZE
-        } else {
-            false
-        }
+    pub fn is_negative_int(&self, ty: DedupPoolId<IRType>) -> bool {
+        let typ = *self.types.get(ty);
+        typ == IRType::U8
+            || typ == IRType::U16
+            || typ == IRType::U32
+            || typ == IRType::U64
+            || typ == IRType::USIZE
     }
 
     ///Retrieves the raw IR type from the provided `id`
-    pub fn get_type(&self, id: IRTypeId) -> IRType {
-        self.types[id.0]
+    pub fn get_type(&self, id: IRTypeId) -> &IRType {
+        self.types.get(id)
     }
 
     ///Gets a mutable referente to the type of the function with the provided `id`
@@ -96,7 +102,7 @@ impl IRTypes {
     ///Panics if `ty` is not a Struct or Component, or if `field_index` is out of bounds.
     pub fn get_field_type(&self, ty: IRTypeId, field_index: u16) -> IRTypeId {
         let field_index = field_index as usize;
-        match self.types[ty.0] {
+        match self.types.get(ty) {
             IRType::Struct(sid) => self.structs[sid.0].get_fields()[field_index],
             IRType::Component(cid) => self.components[cid.0].fields[field_index],
             ref other => panic!(
@@ -120,64 +126,67 @@ impl IRTypes {
     }
 
     #[inline]
-    fn find_type_index(&self, ty: IRType) -> Option<IRTypeId> {
-        self.types.iter().position(|v| *v == ty).map(IRTypeId)
+    ///Inserts the given `ty` and returns its ID.
+    pub fn insert_type(&self, ty: IRType) -> IRTypeId {
+        self.types.insert(ty)
+    }
+
+    pub fn vector_type(&self, ty: IRTypeId) -> IRTypeId {
+        let ty = IRType::Vector(ty);
+        self.insert_type(ty)
     }
 
     ///Returns the int type
     pub fn int_type(&self) -> IRTypeId {
-        self.find_type_index(IRType::I32).unwrap()
+        self.insert_type(IRType::I32)
     }
 
     ///Returns the float type
     pub fn float_type(&self) -> IRTypeId {
-        self.find_type_index(IRType::F32).unwrap()
+        self.insert_type(IRType::F32)
     }
 
     ///Returns the bool type
     pub fn bool_type(&self) -> IRTypeId {
-        self.find_type_index(IRType::BOOL).unwrap()
+        self.insert_type(IRType::BOOL)
     }
 
     ///Returns the void type
     pub fn void_type(&self) -> IRTypeId {
-        self.find_type_index(IRType::VOID).unwrap()
+        self.insert_type(IRType::VOID)
     }
 
     ///Returns the str type
     pub fn str_type(&self) -> IRTypeId {
-        self.find_type_index(IRType::STR).unwrap()
+        self.insert_type(IRType::STR)
     }
 
     ///Returns the usize type
     pub fn usize_type(&self) -> IRTypeId {
-        self.find_type_index(IRType::USIZE).unwrap()
+        self.insert_type(IRType::USIZE)
     }
 
     ///Returns the generic component type
     pub fn generic_component_type(&self) -> IRTypeId {
-        self.find_type_index(IRType::GenericComponent).unwrap()
+        self.insert_type(IRType::GenericComponent)
     }
 
     ///Returns the usize type
     pub fn specialized_div_type(&self) -> IRTypeId {
-        self.find_type_index(IRType::Specialized(IRSpecializedComponentType::Div))
-            .unwrap()
+        self.insert_type(IRType::Specialized(IRSpecializedComponentType::Div))
     }
 
     ///Returns the generic component type
     pub fn specialized_text_type(&self) -> IRTypeId {
-        self.find_type_index(IRType::Specialized(IRSpecializedComponentType::Text))
-            .unwrap()
+        self.insert_type(IRType::Specialized(IRSpecializedComponentType::Text))
     }
     ///Creates a new empty struct and returns its type ID
     pub(crate) fn create_empty_struct(&mut self, name: SymbolPointer) -> (IRTypeId, IRStructId) {
         let sout = self.structs.len();
         self.structs.push(IRStruct::new(Some(name)));
         let struct_id = IRStructId(sout);
-        let out = self.types.len();
-        self.types.push(IRType::Struct(struct_id));
-        (IRTypeId(out), struct_id)
+        let out = self.insert_type(IRType::Struct(struct_id));
+        (out, struct_id)
     }
     ///Creates a new empty struct and returns its type ID
     pub(crate) fn create_empty_component(
@@ -186,29 +195,22 @@ impl IRTypes {
     ) -> (IRTypeId, IRComponentId) {
         let sout = self.components.len();
         self.components.push(IRComponent::new(name));
-        let out = self.types.len();
         let component_id = IRComponentId(sout);
-        self.types.push(IRType::Component(component_id));
-        (IRTypeId(out), component_id)
+        let out = self.insert_type(IRType::Component(component_id));
+        (out, component_id)
     }
     ///Creates a new empty function type with return `void`
     pub(crate) fn create_function_type(&mut self) -> (IRTypeId, IRFunctionId) {
         let fout = self.functions.len();
         self.functions.push(IRFunction::new(&[], self.void_type()));
-        let out = self.types.len();
         let func_id = IRFunctionId(fout);
-        self.types.push(IRType::Function(func_id));
-        (IRTypeId(out), func_id)
+        let out = self.insert_type(IRType::Function(func_id));
+        (out, func_id)
     }
     pub fn create_or_get_tuple(&mut self, elements: Vec<IRTypeId>) -> IRTypeId {
         for (i, strukt) in self.structs.iter().enumerate() {
             if strukt.get_fields() == elements {
-                return IRTypeId(
-                    self.types
-                        .iter()
-                        .position(|t| matches!(t, IRType::Struct(id) if id.0 == i))
-                        .unwrap(),
-                );
+                return self.insert_type(IRType::Struct(IRStructId(i)));
             }
         }
         let mut s = IRStruct::new(None);
@@ -217,8 +219,7 @@ impl IRTypes {
         }
         let sid = IRStructId(self.structs.len());
         self.structs.push(s);
-        let tid = IRTypeId(self.types.len());
-        self.types.push(IRType::Struct(sid));
-        tid
+        let out = self.insert_type(IRType::Struct(sid));
+        out
     }
 }

--- a/crates/ir/src/views/component.rs
+++ b/crates/ir/src/views/component.rs
@@ -7,6 +7,7 @@ impl<'a> IRViewer<'a, Component> {
         let IRType::Component(c) = ty else {
             unreachable!("Type of component internally isnt a component? {ty:?}")
         };
+        let c = *c;
         self.ir.types.get_component_type(c)
     }
 }

--- a/crates/ir/src/views/function.rs
+++ b/crates/ir/src/views/function.rs
@@ -15,6 +15,7 @@ impl<'a> IRViewer<'a, Function> {
         let IRType::Function(id) = self.ir.types.get_type(ty) else {
             unreachable!();
         };
+        let id = *id;
         self.ir.types.get_function_type(id)
     }
 

--- a/crates/ir/src/visualize/formatter.rs
+++ b/crates/ir/src/visualize/formatter.rs
@@ -74,6 +74,14 @@ impl<'a> Formatter<'a> {
             IRType::Component(c) => self.fmt_component_type(c),
             IRType::Specialized(IRSpecializedComponentType::Div) => "@div".to_string(),
             IRType::Specialized(IRSpecializedComponentType::Text) => "@text".to_string(),
+            IRType::Array(t, len) => format!("[{len}]{}", {
+                let ty = self.types.get_type(*t);
+                self.fmt_type(&ty)
+            }),
+            IRType::Vector(t) => format!("[]{}", {
+                let ty = self.types.get_type(*t);
+                self.fmt_type(&ty)
+            }),
         }
     }
 
@@ -138,7 +146,7 @@ impl<'a> Formatter<'a> {
         let IRType::Function(fty) = self.types.get_type(func.ty()) else {
             unreachable!("Type of function should be function");
         };
-        let func_ty = self.types.get_function_type(fty);
+        let func_ty = self.types.get_function_type(*fty);
         let args = func_ty
             .get_args()
             .iter()
@@ -148,7 +156,7 @@ impl<'a> Formatter<'a> {
         let ret_ty = self.fmt_type(
             &self
                 .types
-                .get_type(self.types.get_function_type(fty).get_return_type()),
+                .get_type(self.types.get_function_type(*fty).get_return_type()),
         );
         let mut out = format!(
             "{ret_ty} {}({args}){{\n",
@@ -260,7 +268,7 @@ impl<'a> Formatter<'a> {
         let IRType::Component(cid) = self.types.get_type(component.ir_type()) else {
             unreachable!("Type of component should be Component");
         };
-        let comp_ty = self.types.get_component_type(cid);
+        let comp_ty = self.types.get_component_type(*cid);
         let params = comp_ty
             .fields()
             .iter()

--- a/crates/ir/src/visualize/formatter.rs
+++ b/crates/ir/src/visualize/formatter.rs
@@ -76,11 +76,11 @@ impl<'a> Formatter<'a> {
             IRType::Specialized(IRSpecializedComponentType::Text) => "@text".to_string(),
             IRType::Array(t, len) => format!("[{len}]{}", {
                 let ty = self.types.get_type(*t);
-                self.fmt_type(&ty)
+                self.fmt_type(ty)
             }),
             IRType::Vector(t) => format!("[]{}", {
                 let ty = self.types.get_type(*t);
-                self.fmt_type(&ty)
+                self.fmt_type(ty)
             }),
         }
     }
@@ -93,7 +93,7 @@ impl<'a> Formatter<'a> {
             let fields = strukt
                 .get_fields()
                 .iter()
-                .map(|v| self.fmt_type(&self.types.get_type(*v)))
+                .map(|v| self.fmt_type(self.types.get_type(*v)))
                 .collect::<Vec<_>>()
                 .join(",");
             format!("{{{fields}}}")
@@ -117,7 +117,7 @@ impl<'a> Formatter<'a> {
         {
             let fields = fields
                 .iter()
-                .map(|f| self.fmt_type(&self.types.get_type(*f)))
+                .map(|f| self.fmt_type(self.types.get_type(*f)))
                 .collect::<Vec<_>>()
                 .join(",");
             out.push_str(&format!(
@@ -150,12 +150,11 @@ impl<'a> Formatter<'a> {
         let args = func_ty
             .get_args()
             .iter()
-            .map(|ty| self.fmt_type(&self.types.get_type(*ty)))
+            .map(|ty| self.fmt_type(self.types.get_type(*ty)))
             .collect::<Vec<_>>()
             .join(", ");
         let ret_ty = self.fmt_type(
-            &self
-                .types
+            self.types
                 .get_type(self.types.get_function_type(*fty).get_return_type()),
         );
         let mut out = format!(
@@ -272,7 +271,7 @@ impl<'a> Formatter<'a> {
         let params = comp_ty
             .fields()
             .iter()
-            .map(|v| self.fmt_type(&self.types.get_type(*v)))
+            .map(|v| self.fmt_type(self.types.get_type(*v)))
             .collect::<Vec<_>>();
 
         let fields = params
@@ -288,9 +287,9 @@ impl<'a> Formatter<'a> {
             .map(|(idx, c)| {
                 let ty = self.ir.get_type(*c);
                 let ty = if let IRType::Component(component) = ty {
-                    self.fmt_component_type(&component)
+                    self.fmt_component_type(component)
                 } else {
-                    self.fmt_type(&ty)
+                    self.fmt_type(ty)
                 };
 
                 format!("  #c{idx}: {ty};")
@@ -477,7 +476,7 @@ impl<'a> Formatter<'a> {
             Opcode::AShr => self.fmt_binary("ashr", instr),
 
             Opcode::GetField(index) => {
-                let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
+                let ty_str = self.fmt_type(self.types.get_type(instr.value_type));
                 let target = self.fmt_value(instr.operands[0]);
                 format!("getfield {ty_str}, {target}, {index};")
             }
@@ -512,11 +511,11 @@ impl<'a> Formatter<'a> {
             Opcode::Allocate => {
                 format!(
                     "allocate {};",
-                    self.fmt_type(&self.types.get_type(instr.value_type))
+                    self.fmt_type(self.types.get_type(instr.value_type))
                 )
             }
             Opcode::Write => {
-                let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
+                let ty_str = self.fmt_type(self.types.get_type(instr.value_type));
                 format!(
                     "write {ty_str}, {}, {};",
                     self.fmt_value(instr.operands[0]),
@@ -524,11 +523,11 @@ impl<'a> Formatter<'a> {
                 )
             }
             Opcode::Read => {
-                let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
+                let ty_str = self.fmt_type(self.types.get_type(instr.value_type));
                 format!("read {ty_str}, {};", self.fmt_value(instr.operands[0]))
             }
             Opcode::Reinterpret => {
-                let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
+                let ty_str = self.fmt_type(self.types.get_type(instr.value_type));
                 format!(
                     "reinterpret {ty_str}, {};",
                     self.fmt_value(instr.operands[0])
@@ -561,7 +560,7 @@ impl<'a> Formatter<'a> {
                 format!("@initcall {name}, {comp};")
             }
             Opcode::Struct | Opcode::Component => {
-                let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
+                let ty_str = self.fmt_type(self.types.get_type(instr.value_type));
                 let args = self.fmt_operands(&instr.operands);
                 format!("{ty_str}{{{args}}}")
             }
@@ -621,7 +620,7 @@ impl<'a> Formatter<'a> {
     }
 
     fn fmt_binary(&self, op: &str, instr: &Instruction) -> String {
-        let ty_str = self.fmt_type(&self.types.get_type(instr.value_type));
+        let ty_str = self.fmt_type(self.types.get_type(instr.value_type));
         let a = self.fmt_value(instr.operands[0]);
         let b = self.fmt_value(instr.operands[1]);
         format!("{} {}, {}, {};", op, ty_str, a, b)

--- a/crates/ir/src/visualize/formatter.rs
+++ b/crates/ir/src/visualize/formatter.rs
@@ -421,6 +421,8 @@ impl<'a> Formatter<'a> {
 
     pub fn format_instruction(&self, instr: &Instruction) -> String {
         match &instr.opcode {
+            Opcode::Array => format!("[{}]", self.fmt_operands(&instr.operands)),
+            Opcode::Vector => format!("vec[{}]", self.fmt_operands(&instr.operands)),
             Opcode::GlobalExtern(global) => format!("@extern \"{}\"", self.ir.get_name(*global)),
             Opcode::Global(global_value) => self.fmt_global(*global_value),
             Opcode::Br(label_ptr) => {

--- a/crates/ir/src/visualize/formatter.rs
+++ b/crates/ir/src/visualize/formatter.rs
@@ -421,6 +421,7 @@ impl<'a> Formatter<'a> {
 
     pub fn format_instruction(&self, instr: &Instruction) -> String {
         match &instr.opcode {
+            Opcode::ArrayGet => format!("array_get {}", self.fmt_operands(&instr.operands)),
             Opcode::Array => format!("[{}]", self.fmt_operands(&instr.operands)),
             Opcode::Vector => format!("vec[{}]", self.fmt_operands(&instr.operands)),
             Opcode::GlobalExtern(global) => format!("@extern \"{}\"", self.ir.get_name(*global)),

--- a/crates/lexer/src/tokens.rs
+++ b/crates/lexer/src/tokens.rs
@@ -101,6 +101,10 @@ pub enum TokenKind {
     LBrace,
     #[token("}")]
     RBrace,
+    #[token("[")]
+    LBracket,
+    #[token("]")]
+    RBracket,
     #[token(";")]
     SemiColon,
     #[token("<")]

--- a/crates/module_loader/src/lib.rs
+++ b/crates/module_loader/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
 
 use common::{FrontendSymbol, Span, SymbolsModule, pool::DedupPool};
 use slynx_lexer::Lexer;
-use slynx_parser::{ASTExpression, ASTPath, ASTStatement, FileImport, GenericIdentifier, Parser};
+use slynx_parser::{ASTExpression, ASTPath, ASTStatement, FileImport, Parser, Type};
 use slynx_parser::{Program, SymbolPointer};
 
 pub trait SourceProvider<'a> {
@@ -22,7 +22,7 @@ pub struct SourceLoader<'a> {
     symbols: &'a SymbolsModule<FrontendSymbol>,
     statements: &'a DedupPool<ASTStatement>,
     expressions: &'a DedupPool<ASTExpression>,
-    types: &'a DedupPool<GenericIdentifier>,
+    types: &'a DedupPool<Type>,
 }
 
 impl<'a> SourceLoader<'a> {
@@ -30,7 +30,7 @@ impl<'a> SourceLoader<'a> {
         symbols: &'a SymbolsModule<FrontendSymbol>,
         statements: &'a DedupPool<ASTStatement>,
         expressions: &'a DedupPool<ASTExpression>,
-        types: &'a DedupPool<GenericIdentifier>,
+        types: &'a DedupPool<Type>,
     ) -> Self {
         Self {
             symbols,

--- a/crates/module_loader/src/modules.rs
+++ b/crates/module_loader/src/modules.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::PathBuf};
 use common::{FrontendSymbol, SymbolPointer, SymbolsModule, pool::DedupPoolId};
 use slynx_parser::{
     ASTExpression, ASTPath, ASTStatement, AliasDeclaration, ComponentDeclaration,
-    GenericIdentifier, ObjectDeclaration,
+    ObjectDeclaration, Type,
 };
 
 use crate::{FileId, SourceLoader, SourceNode};
@@ -84,8 +84,11 @@ impl<'a> Modules<'a> {
     pub fn get_statement(&self, stmt: DedupPoolId<ASTStatement>) -> &ASTStatement {
         self.loader.statements.get(stmt)
     }
-    pub fn get_type(&self, ty: DedupPoolId<GenericIdentifier>) -> &GenericIdentifier {
+    pub fn get_type(&self, ty: DedupPoolId<Type>) -> &Type {
         self.loader.types.get(ty)
+    }
+    pub fn type_name(&self, ty: DedupPoolId<Type>) -> SymbolPointer<FrontendSymbol> {
+        self.loader.types.get(ty).name()
     }
 
     pub fn find_function_declaration(
@@ -95,8 +98,8 @@ impl<'a> Modules<'a> {
     ) -> Option<(FileId, &slynx_parser::FuncDeclaration)> {
         let module = &self.modules[module.as_raw() as usize];
         if let Some(v) = module.func().iter().find(|func| {
-            let t = self.loader.types.get(func.name.data);
-            t.identifier == name
+            let t = self.type_name(func.name.data);
+            t == name
         }) {
             return Some((module.id, v));
         }
@@ -165,7 +168,7 @@ impl<'a> Modules<'a> {
         let module_ref = &self.modules[raw];
 
         if let Some(strukt) = module_ref.object().iter().find_map(|strukt| {
-            let strukt_name = self.get_type(strukt.name.data).identifier;
+            let strukt_name = self.type_name(strukt.name.data);
             (strukt_name == name).then_some(ASTType {
                 owner: module,
                 content: ASTTypeKind::Struct(strukt),
@@ -174,7 +177,7 @@ impl<'a> Modules<'a> {
             return Some(strukt);
         }
         if let Some(component) = module_ref.component().iter().find_map(|component| {
-            let component_name = self.get_type(component.name.data).identifier;
+            let component_name = self.type_name(component.name.data);
             (component_name == name).then_some(ASTType {
                 owner: module,
                 content: ASTTypeKind::Component(component),
@@ -184,7 +187,7 @@ impl<'a> Modules<'a> {
         }
 
         if let Some(alias) = module_ref.alias().iter().find_map(|alias| {
-            let alias_name = self.get_type(alias.name.data).identifier;
+            let alias_name = self.type_name(alias.name.data);
             (alias_name == name).then_some(ASTType {
                 owner: module,
                 content: ASTTypeKind::Alias(alias),

--- a/crates/module_loader/src/modules.rs
+++ b/crates/module_loader/src/modules.rs
@@ -88,7 +88,23 @@ impl<'a> Modules<'a> {
         self.loader.types.get(ty)
     }
     pub fn type_name(&self, ty: DedupPoolId<Type>) -> SymbolPointer<FrontendSymbol> {
-        self.loader.types.get(ty).name()
+        match &self.loader.types[ty] {
+            Type::Plain(gi) => gi.identifier,
+            Type::Array(arr, len) => {
+                let name = self.loader.symbols.get_name(self.type_name(*arr));
+                let len = match self.loader.expressions.get(*len) {
+                    ASTExpression::IntLiteral(int) => int.to_string(),
+                    _ => unimplemented!(
+                        "This is not supported. An array type should contain a number inside it to determine its size. This is an expression due to the possibility of comptime, that is idealized. But at the moment only integer literals are accepted"
+                    ),
+                };
+                self.loader.symbols.intern(&format!("[{len}]{name}"))
+            }
+            Type::Vector(inner) => self.loader.symbols.intern(&format!(
+                "[]{}",
+                self.loader.symbols.get_name(self.type_name(*inner))
+            )),
+        }
     }
 
     pub fn find_function_declaration(

--- a/crates/parser/src/ast/component.rs
+++ b/crates/parser/src/ast/component.rs
@@ -1,6 +1,6 @@
 use crate::{
     SymbolPointer,
-    ast::{ASTExpression, GenericIdentifier, VisibilityModifier},
+    ast::{ASTExpression, Type, VisibilityModifier},
 };
 use common::{Span, Spanned, pool::DedupPoolId};
 #[derive(Debug)]
@@ -14,7 +14,7 @@ pub enum ComponentMemberKind {
     Property {
         name: SymbolPointer,
         modifier: VisibilityModifier,
-        ty: Option<Spanned<DedupPoolId<GenericIdentifier>>>,
+        ty: Option<Spanned<DedupPoolId<Type>>>,
         rhs: Option<Spanned<DedupPoolId<ASTExpression>>>,
     },
     Child(Spanned<ComponentExpression>),
@@ -30,6 +30,6 @@ pub enum ComponentMemberValue {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct ComponentExpression {
-    pub name: Spanned<DedupPoolId<GenericIdentifier>>,
+    pub name: Spanned<DedupPoolId<Type>>,
     pub values: Vec<ComponentMemberValue>,
 }

--- a/crates/parser/src/ast/declarations.rs
+++ b/crates/parser/src/ast/declarations.rs
@@ -1,7 +1,7 @@
 use common::{Span, Spanned, VisibilityModifier, pool::DedupPoolId};
 
 use crate::{
-    ASTExpression, ASTStatement, ComponentMember, GenericIdentifier, ObjectField,
+    ASTExpression, ASTStatement, ComponentMember, ObjectField, Type,
     StyleSheetStatement, SymbolPointer, TypedName,
 };
 
@@ -14,23 +14,23 @@ pub struct ASTAttribute {
 
 #[derive(Debug)]
 pub struct ObjectMethod {
-    pub method_name: Spanned<DedupPoolId<GenericIdentifier>>,
+    pub method_name: Spanned<DedupPoolId<Type>>,
     pub arguments: Vec<Spanned<TypedName>>,
-    pub return_type: Spanned<DedupPoolId<GenericIdentifier>>,
+    pub return_type: Spanned<DedupPoolId<Type>>,
     pub body: Vec<Spanned<DedupPoolId<ASTStatement>>>,
     pub span: Span,
 }
 
 #[derive(Debug)]
 pub struct AliasDeclaration {
-    pub name: Spanned<DedupPoolId<GenericIdentifier>>,
-    pub target: Spanned<DedupPoolId<GenericIdentifier>>,
+    pub name: Spanned<DedupPoolId<Type>>,
+    pub target: Spanned<DedupPoolId<Type>>,
     pub span: Span,
     pub visibility: VisibilityModifier,
 }
 #[derive(Debug)]
 pub struct ObjectDeclaration {
-    pub name: Spanned<DedupPoolId<GenericIdentifier>>,
+    pub name: Spanned<DedupPoolId<Type>>,
     pub fields: Vec<ObjectField>,
     pub methods: Vec<ObjectMethod>,
     pub attributes: Vec<Spanned<ASTAttribute>>,
@@ -40,7 +40,7 @@ pub struct ObjectDeclaration {
 }
 #[derive(Debug)]
 pub struct ComponentDeclaration {
-    pub name: Spanned<DedupPoolId<GenericIdentifier>>,
+    pub name: Spanned<DedupPoolId<Type>>,
     pub members: Vec<ComponentMember>,
     pub attributes: Vec<Spanned<ASTAttribute>>,
     pub visibility: VisibilityModifier,
@@ -48,9 +48,9 @@ pub struct ComponentDeclaration {
 }
 #[derive(Debug)]
 pub struct FuncDeclaration {
-    pub name: Spanned<DedupPoolId<GenericIdentifier>>,
+    pub name: Spanned<DedupPoolId<Type>>,
     pub args: Vec<Spanned<TypedName>>,
-    pub return_type: Spanned<DedupPoolId<GenericIdentifier>>,
+    pub return_type: Spanned<DedupPoolId<Type>>,
     pub body: Vec<Spanned<DedupPoolId<ASTStatement>>>,
     pub attributes: Vec<Spanned<ASTAttribute>>,
     pub visibility: VisibilityModifier,
@@ -59,7 +59,7 @@ pub struct FuncDeclaration {
 }
 #[derive(Debug)]
 pub struct StyleSheet {
-    pub name: Spanned<DedupPoolId<GenericIdentifier>>,
+    pub name: Spanned<DedupPoolId<Type>>,
     pub args: Vec<Spanned<TypedName>>,
     pub usages: Vec<Spanned<DedupPoolId<ASTExpression>>>,
     pub body: Vec<Spanned<StyleSheetStatement>>,
@@ -70,7 +70,7 @@ pub struct StyleSheet {
 #[derive(Debug)]
 pub struct StaticDeclaration {
     pub name: SymbolPointer,
-    pub ty: Spanned<DedupPoolId<GenericIdentifier>>,
+    pub ty: Spanned<DedupPoolId<Type>>,
     pub value: Option<Spanned<DedupPoolId<ASTExpression>>>, //option because, if not provided, it yet can be used, even though might lead to runtime bugs. Should be None only on externs
     pub attributes: Vec<Spanned<ASTAttribute>>,
     pub visibility: VisibilityModifier,

--- a/crates/parser/src/ast/declarations.rs
+++ b/crates/parser/src/ast/declarations.rs
@@ -1,8 +1,8 @@
 use common::{Span, Spanned, VisibilityModifier, pool::DedupPoolId};
 
 use crate::{
-    ASTExpression, ASTStatement, ComponentMember, ObjectField, Type,
-    StyleSheetStatement, SymbolPointer, TypedName,
+    ASTExpression, ASTStatement, ComponentMember, ObjectField, StyleSheetStatement, SymbolPointer,
+    Type, TypedName,
 };
 
 #[derive(Debug)]

--- a/crates/parser/src/ast/expression.rs
+++ b/crates/parser/src/ast/expression.rs
@@ -1,6 +1,6 @@
 use crate::{
     ASTStatement, SymbolPointer,
-    ast::{ComponentExpression, GenericIdentifier},
+    ast::{ComponentExpression, Type},
 };
 use common::{Operator, Spanned, pool::DedupPoolId};
 use ordered_float::OrderedFloat;
@@ -33,7 +33,7 @@ pub enum ASTExpression {
         rhs: Spanned<DedupPoolId<ASTExpression>>,
     },
     ObjectExpression {
-        name: Spanned<DedupPoolId<GenericIdentifier>>,
+        name: Spanned<DedupPoolId<Type>>,
         fields: SmallVec<[Spanned<NamedExpr>; 4]>,
     },
     FieldAccess {
@@ -41,7 +41,7 @@ pub enum ASTExpression {
         field: Spanned<DedupPoolId<ASTExpression>>,
     },
     FunctionCall {
-        name: Spanned<DedupPoolId<GenericIdentifier>>,
+        name: Spanned<DedupPoolId<Type>>,
         args: SmallVec<[Spanned<DedupPoolId<ASTExpression>>; 7]>,
     },
     If {

--- a/crates/parser/src/ast/expression.rs
+++ b/crates/parser/src/ast/expression.rs
@@ -14,6 +14,23 @@ pub struct NamedExpr {
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum RangeType {
+    ///Range type that represents everything. Same as rust's '..'
+    All,
+    ///Range type that represents where it starts from. Same as rust's 'x..'
+    From(Spanned<DedupPoolId<ASTExpression>>),
+    ///Range type that represents where it ends at. Same as rust's '..x'
+    To(Spanned<DedupPoolId<ASTExpression>>),
+    ///Normal range representing where it starts and where it ends at. Same as rust's 'x..y'
+    Normal {
+        from: Spanned<DedupPoolId<ASTExpression>>,
+        to: Spanned<DedupPoolId<ASTExpression>>,
+    },
+    ///A basic index without ranges at all
+    NoRange(Spanned<DedupPoolId<ASTExpression>>),
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum ASTExpression {
     IntLiteral(i32),
     StringLiteral(SymbolPointer),
@@ -50,6 +67,7 @@ pub enum ASTExpression {
         else_body: Vec<Spanned<DedupPoolId<ASTStatement>>>,
     },
     Array(SmallVec<[Spanned<DedupPoolId<ASTExpression>>; 2]>),
+    IndexExpression(Spanned<DedupPoolId<ASTExpression>>, RangeType),
 }
 
 impl ASTExpression {

--- a/crates/parser/src/ast/expression.rs
+++ b/crates/parser/src/ast/expression.rs
@@ -49,6 +49,7 @@ pub enum ASTExpression {
         body: Vec<Spanned<DedupPoolId<ASTStatement>>>,
         else_body: Vec<Spanned<DedupPoolId<ASTStatement>>>,
     },
+    Array(SmallVec<[Spanned<DedupPoolId<ASTExpression>>; 2]>),
 }
 
 impl ASTExpression {

--- a/crates/parser/src/ast/expression.rs
+++ b/crates/parser/src/ast/expression.rs
@@ -67,6 +67,7 @@ pub enum ASTExpression {
         else_body: Vec<Spanned<DedupPoolId<ASTStatement>>>,
     },
     Array(SmallVec<[Spanned<DedupPoolId<ASTExpression>>; 2]>),
+    Vector(SmallVec<[Spanned<DedupPoolId<ASTExpression>>; 2]>),
     IndexExpression(Spanned<DedupPoolId<ASTExpression>>, RangeType),
 }
 

--- a/crates/parser/src/ast/statement.rs
+++ b/crates/parser/src/ast/statement.rs
@@ -1,17 +1,17 @@
 use common::{Spanned, pool::DedupPoolId};
 
-use crate::{ASTExpression, GenericIdentifier, NamedExpr, StyleState, SymbolPointer};
+use crate::{ASTExpression, NamedExpr, StyleState, SymbolPointer, Type};
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum ASTStatement {
     Var {
         name: SymbolPointer,
-        ty: Option<Spanned<DedupPoolId<GenericIdentifier>>>,
+        ty: Option<Spanned<DedupPoolId<Type>>>,
         rhs: Spanned<DedupPoolId<ASTExpression>>,
     },
     MutableVar {
         name: SymbolPointer,
-        ty: Option<Spanned<DedupPoolId<GenericIdentifier>>>,
+        ty: Option<Spanned<DedupPoolId<Type>>>,
         rhs: Spanned<DedupPoolId<ASTExpression>>,
     },
     Assign {

--- a/crates/parser/src/ast/types.rs
+++ b/crates/parser/src/ast/types.rs
@@ -1,22 +1,41 @@
 use std::hash::Hash;
 
-use common::{Spanned, VisibilityModifier, pool::DedupPoolId};
+use common::{
+    Spanned, VisibilityModifier,
+    pool::DedupPoolId,
+};
 use smallvec::SmallVec;
 
-use crate::SymbolPointer;
+use crate::{ASTExpression, SymbolPointer};
 
 #[derive(Debug)]
 ///A name that is typed. This is simply the representation of `name: kind`
 pub struct TypedName {
     pub name: SymbolPointer,
-    pub kind: Spanned<DedupPoolId<GenericIdentifier>>,
+    pub kind: Spanned<DedupPoolId<Type>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub enum Type {
+    Plain(GenericIdentifier),
+    Array(DedupPoolId<Type>, DedupPoolId<ASTExpression>),
+    Vector(DedupPoolId<Type>),
+}
+
+impl Type {
+    pub fn name(&self) -> SymbolPointer {
+        match self {
+            Type::Plain(gi) => gi.identifier,
+            _ => panic!("expected named type"),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 ///A Identifier that might contain a generic. Such as `Component<int>`
 pub struct GenericIdentifier {
     ///The generic this identifier contains.
-    pub generic: SmallVec<[DedupPoolId<GenericIdentifier>; 2]>,
+    pub generic: SmallVec<[Spanned<DedupPoolId<Type>>; 2]>,
     ///The name of this identifier
     pub identifier: SymbolPointer,
 }

--- a/crates/parser/src/ast/types.rs
+++ b/crates/parser/src/ast/types.rs
@@ -1,9 +1,6 @@
 use std::hash::Hash;
 
-use common::{
-    Spanned, VisibilityModifier,
-    pool::DedupPoolId,
-};
+use common::{Spanned, VisibilityModifier, pool::DedupPoolId};
 use smallvec::SmallVec;
 
 use crate::{ASTExpression, SymbolPointer};
@@ -20,15 +17,6 @@ pub enum Type {
     Plain(GenericIdentifier),
     Array(DedupPoolId<Type>, DedupPoolId<ASTExpression>),
     Vector(DedupPoolId<Type>),
-}
-
-impl Type {
-    pub fn name(&self) -> SymbolPointer {
-        match self {
-            Type::Plain(gi) => gi.identifier,
-            _ => panic!("expected named type"),
-        }
-    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -20,12 +20,19 @@ pub enum ParseError {
     UnexpectedEndOfInput,
     NoStyleUsagesProvided,
     InvalidPostfix(Span),
+    ExpectedIndexExpression,
 }
 
 impl std::fmt::Display for ParseError {
     ///Formats the `ParseError` into a human-readable string. It matches on the type of error and constructs an appropriate message. For `UnexpectedToken`, it includes the unexpected token and what was expected. For `UnexpectedEndOfInput`, it simply states that the end of input was unexpected.
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
+            ParseError::ExpectedIndexExpression => {
+                write!(
+                    f,
+                    "Was expecting an expression or range which could be used as an index"
+                )
+            }
             ParseError::UnexpectedToken(token, expected_ty) => {
                 let expected = match expected_ty {
                     ExpectedContent::ParsingContext(ParserContext::OnlySignatures) => {

--- a/crates/parser/src/error.rs
+++ b/crates/parser/src/error.rs
@@ -20,19 +20,12 @@ pub enum ParseError {
     UnexpectedEndOfInput,
     NoStyleUsagesProvided,
     InvalidPostfix(Span),
-    ExpectedIndexExpression,
 }
 
 impl std::fmt::Display for ParseError {
     ///Formats the `ParseError` into a human-readable string. It matches on the type of error and constructs an appropriate message. For `UnexpectedToken`, it includes the unexpected token and what was expected. For `UnexpectedEndOfInput`, it simply states that the end of input was unexpected.
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            ParseError::ExpectedIndexExpression => {
-                write!(
-                    f,
-                    "Was expecting an expression or range which could be used as an index"
-                )
-            }
             ParseError::UnexpectedToken(token, expected_ty) => {
                 let expected = match expected_ty {
                     ExpectedContent::ParsingContext(ParserContext::OnlySignatures) => {

--- a/crates/parser/src/expr.rs
+++ b/crates/parser/src/expr.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ASTExpression, ComponentExpression, ComponentMemberValue, ExpectedContent, GenericIdentifier,
+    ASTExpression, ComponentExpression, ComponentMemberValue, ExpectedContent, Type,
     NamedExpr,
 };
 use crate::{Parser, Result, error::ParseError};
@@ -54,7 +54,7 @@ impl Parser<'_> {
     ///Parses an component expression but, starting from the LBrace, assuming the name of the component is the provided `name`
     pub fn parse_component_expr_with_name(
         &mut self,
-        name: Spanned<DedupPoolId<GenericIdentifier>>,
+        name: Spanned<DedupPoolId<Type>>,
     ) -> Result<Spanned<ComponentExpression>> {
         let mut span = name.span;
         self.expect(&TokenKind::LBrace)?;

--- a/crates/parser/src/expr.rs
+++ b/crates/parser/src/expr.rs
@@ -532,18 +532,17 @@ impl Parser<'_> {
                             .merge_with(bracket_span)
                             .make_spanned(expr))
                     }
-                    (_, TokenKind::RBracket) => {
+                    (_, _) => {
                         let expr = self.intern_expression(ASTExpression::IndexExpression(
                             arr_expression,
                             RangeType::NoRange(expr),
                         ));
-                        let bracket_span = self.eat()?.span;
+                        let bracket_span = self.expect(&TokenKind::RBracket)?.span;
                         Ok(arr_expression
                             .span
                             .merge_with(bracket_span)
                             .make_spanned(expr))
                     }
-                    _ => Err(ParseError::ExpectedIndexExpression),
                 }
             }
         }

--- a/crates/parser/src/expr.rs
+++ b/crates/parser/src/expr.rs
@@ -471,6 +471,24 @@ impl Parser<'_> {
         let id = self.intern_expression(ASTExpression::Array(exprs));
         Ok(span.merge_with(end).make_spanned(id))
     }
+    ///Parses a vector literal, which is delimited by `{` and `}`. Unlike array
+    ///literals, the size of a vector is not known, so it is dynamic.
+    pub fn parse_vector(&mut self, span: Span) -> Result<Spanned<DedupPoolId<ASTExpression>>> {
+        let mut exprs = SmallVec::new();
+        loop {
+            if self.peek()?.kind == TokenKind::RBrace {
+                break;
+            }
+            let expr = self.parse_expression()?;
+            exprs.push(expr);
+            if self.peek()?.kind != TokenKind::RBrace {
+                self.expect(&TokenKind::Comma)?;
+            }
+        }
+        let end = self.expect(&TokenKind::RBrace)?.span;
+        let id = self.intern_expression(ASTExpression::Vector(exprs));
+        Ok(span.merge_with(end).make_spanned(id))
+    }
     ///Parses an array access on the given `arr_expression` expression. And the given ¯span` its the span of the left bracket.This function starts right after the '['. So a[5], this function starts looking up to '5'
     pub fn parse_array_access(
         &mut self,
@@ -558,6 +576,10 @@ impl Parser<'_> {
             TokenKind::LBracket => {
                 let span = self.eat()?.span;
                 self.parse_array(span)
+            }
+            TokenKind::LBrace => {
+                let span = self.eat()?.span;
+                self.parse_vector(span)
             }
             _ => self.parse_logical(),
         }?;

--- a/crates/parser/src/expr.rs
+++ b/crates/parser/src/expr.rs
@@ -493,7 +493,7 @@ impl Parser<'_> {
     pub fn parse_array_access(
         &mut self,
         arr_expression: Spanned<DedupPoolId<ASTExpression>>,
-        span: Span,
+        _: Span,
     ) -> Result<Spanned<DedupPoolId<ASTExpression>>> {
         match (self.peek()?.kind.clone(), self.peek_at(1)?.kind.clone()) {
             (TokenKind::Colon, TokenKind::RBracket) => {

--- a/crates/parser/src/expr.rs
+++ b/crates/parser/src/expr.rs
@@ -1,6 +1,5 @@
 use crate::{
-    ASTExpression, ComponentExpression, ComponentMemberValue, ExpectedContent, Type,
-    NamedExpr,
+    ASTExpression, ComponentExpression, ComponentMemberValue, ExpectedContent, NamedExpr, Type,
 };
 use crate::{Parser, Result, error::ParseError};
 use common::pool::DedupPoolId;
@@ -455,12 +454,33 @@ impl Parser<'_> {
         Ok(lhs)
     }
 
+    pub fn parse_array(&mut self, span: Span) -> Result<Spanned<DedupPoolId<ASTExpression>>> {
+        let mut exprs = SmallVec::new();
+        loop {
+            if self.peek()?.kind == TokenKind::RBracket {
+                break;
+            }
+            let expr = self.parse_expression()?;
+            self.expect(&TokenKind::Comma)?;
+            exprs.push(expr);
+        }
+        let end = self.expect(&TokenKind::RBracket)?.span;
+        let id = self.intern_expression(ASTExpression::Array(exprs));
+        Ok(span.merge_with(end).make_spanned(id))
+    }
+
     /// Parses an expression, which is the top-level function for parsing any kind of expression. It starts by parsing a logical expression, which can include comparisons, additive, multiplicative, and primary expressions, and returns the resulting ASTExpression.
     pub fn parse_expression(&mut self) -> Result<Spanned<DedupPoolId<ASTExpression>>> {
-        if self.peek()?.kind == TokenKind::If {
-            let span = self.eat()?.span;
-            return self.parse_if(span);
+        match self.peek()?.kind {
+            TokenKind::If => {
+                let span = self.eat()?.span;
+                self.parse_if(span)
+            }
+            TokenKind::LBracket => {
+                let span = self.eat()?.span;
+                self.parse_array(span)
+            }
+            _ => self.parse_logical(),
         }
-        self.parse_logical()
     }
 }

--- a/crates/parser/src/expr.rs
+++ b/crates/parser/src/expr.rs
@@ -1,5 +1,6 @@
 use crate::{
-    ASTExpression, ComponentExpression, ComponentMemberValue, ExpectedContent, NamedExpr, Type,
+    ASTExpression, ComponentExpression, ComponentMemberValue, ExpectedContent, NamedExpr,
+    RangeType, Type,
 };
 use crate::{Parser, Result, error::ParseError};
 use common::pool::DedupPoolId;
@@ -461,17 +462,96 @@ impl Parser<'_> {
                 break;
             }
             let expr = self.parse_expression()?;
-            self.expect(&TokenKind::Comma)?;
             exprs.push(expr);
+            if self.peek()?.kind != TokenKind::RBracket {
+                self.expect(&TokenKind::Comma)?;
+            }
         }
         let end = self.expect(&TokenKind::RBracket)?.span;
         let id = self.intern_expression(ASTExpression::Array(exprs));
         Ok(span.merge_with(end).make_spanned(id))
     }
+    ///Parses an array access on the given `arr_expression` expression. And the given ¯span` its the span of the left bracket.This function starts right after the '['. So a[5], this function starts looking up to '5'
+    pub fn parse_array_access(
+        &mut self,
+        arr_expression: Spanned<DedupPoolId<ASTExpression>>,
+        span: Span,
+    ) -> Result<Spanned<DedupPoolId<ASTExpression>>> {
+        match (self.peek()?.kind.clone(), self.peek_at(1)?.kind.clone()) {
+            (TokenKind::Colon, TokenKind::RBracket) => {
+                //parses [:]
+                self.eat()?; //:
+                let end = self.eat()?.span; //]
+                let expr = self.intern_expression(ASTExpression::IndexExpression(
+                    arr_expression,
+                    RangeType::All,
+                ));
+                Ok(arr_expression.span.merge_with(end).make_spanned(expr))
+            }
+            (TokenKind::Colon, _) => {
+                self.eat()?;
+                let expr = self.parse_expression()?;
+                let expr = self.intern_expression(ASTExpression::IndexExpression(
+                    arr_expression,
+                    RangeType::To(expr),
+                ));
+                let bracket_span = self.expect(&TokenKind::RBracket)?.span;
+                Ok(arr_expression
+                    .span
+                    .merge_with(bracket_span)
+                    .make_spanned(expr))
+            }
+            _ => {
+                let expr = self.parse_expression()?;
+                match (self.peek()?.kind.clone(), self.peek_at(1)?.kind.clone()) {
+                    (TokenKind::Colon, TokenKind::RBracket) => {
+                        self.eat()?;
+                        let bracket_span = self.eat()?.span;
+                        let expr = self.intern_expression(ASTExpression::IndexExpression(
+                            arr_expression,
+                            RangeType::From(expr),
+                        ));
+                        Ok(arr_expression
+                            .span
+                            .merge_with(bracket_span)
+                            .make_spanned(expr))
+                    }
+                    (TokenKind::Colon, _) => {
+                        self.eat()?;
+                        let end_expr = self.parse_expression()?;
+                        let bracket_span = self.eat()?.span;
+                        let expr = self.intern_expression(ASTExpression::IndexExpression(
+                            arr_expression,
+                            RangeType::Normal {
+                                from: expr,
+                                to: end_expr,
+                            },
+                        ));
+                        Ok(arr_expression
+                            .span
+                            .merge_with(bracket_span)
+                            .make_spanned(expr))
+                    }
+                    (_, TokenKind::RBracket) => {
+                        let expr = self.intern_expression(ASTExpression::IndexExpression(
+                            arr_expression,
+                            RangeType::NoRange(expr),
+                        ));
+                        let bracket_span = self.eat()?.span;
+                        Ok(arr_expression
+                            .span
+                            .merge_with(bracket_span)
+                            .make_spanned(expr))
+                    }
+                    _ => Err(ParseError::ExpectedIndexExpression),
+                }
+            }
+        }
+    }
 
     /// Parses an expression, which is the top-level function for parsing any kind of expression. It starts by parsing a logical expression, which can include comparisons, additive, multiplicative, and primary expressions, and returns the resulting ASTExpression.
     pub fn parse_expression(&mut self) -> Result<Spanned<DedupPoolId<ASTExpression>>> {
-        match self.peek()?.kind {
+        let expr = match self.peek()?.kind {
             TokenKind::If => {
                 let span = self.eat()?.span;
                 self.parse_if(span)
@@ -481,6 +561,12 @@ impl Parser<'_> {
                 self.parse_array(span)
             }
             _ => self.parse_logical(),
+        }?;
+        if self.peek()?.kind == TokenKind::LBracket {
+            let span = self.eat()?.span;
+            self.parse_array_access(expr, span)
+        } else {
+            Ok(expr)
         }
     }
 }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -28,7 +28,7 @@ pub struct Parser<'a> {
     symbols: &'a SymbolsModule<FrontendSymbol>,
     expressions: &'a DedupPool<ASTExpression>,
     statements: &'a DedupPool<ASTStatement>,
-    types: &'a DedupPool<GenericIdentifier>,
+    types: &'a DedupPool<Type>,
     flags: ParserFlags,
     stream: TokenStream,
 }
@@ -40,7 +40,7 @@ impl<'a> Parser<'a> {
         symbols: &'a SymbolsModule<FrontendSymbol>,
         expressions: &'a DedupPool<ASTExpression>,
         statements: &'a DedupPool<ASTStatement>,
-        types: &'a DedupPool<GenericIdentifier>,
+        types: &'a DedupPool<Type>,
     ) -> Self {
         Parser {
             types,

--- a/crates/parser/src/queries.rs
+++ b/crates/parser/src/queries.rs
@@ -2,8 +2,8 @@ use common::{Span, pool::DedupPoolId};
 use slynx_lexer::{Token, TokenKind};
 
 use crate::{
-    ASTExpression, ASTStatement, ExpectedContent, GenericIdentifier, ParseError, Parser, Result,
-    SymbolPointer, flags::ParserFlag,
+    ASTExpression, ASTStatement, ExpectedContent, ParseError, Parser, Result,
+    SymbolPointer, Type, flags::ParserFlag,
 };
 
 impl<'a> Parser<'a> {
@@ -16,7 +16,7 @@ impl<'a> Parser<'a> {
     pub fn intern_expression(&self, expr: ASTExpression) -> DedupPoolId<ASTExpression> {
         self.expressions.insert(expr)
     }
-    pub fn intern_type(&self, name: GenericIdentifier) -> DedupPoolId<GenericIdentifier> {
+    pub fn intern_type(&self, name: Type) -> DedupPoolId<Type> {
         self.types.insert(name)
     }
     pub fn reset_flags(&mut self) {

--- a/crates/parser/src/queries.rs
+++ b/crates/parser/src/queries.rs
@@ -2,8 +2,8 @@ use common::{Span, pool::DedupPoolId};
 use slynx_lexer::{Token, TokenKind};
 
 use crate::{
-    ASTExpression, ASTStatement, ExpectedContent, ParseError, Parser, Result,
-    SymbolPointer, Type, flags::ParserFlag,
+    ASTExpression, ASTStatement, ExpectedContent, ParseError, Parser, Result, SymbolPointer, Type,
+    flags::ParserFlag,
 };
 
 impl<'a> Parser<'a> {

--- a/crates/parser/src/types.rs
+++ b/crates/parser/src/types.rs
@@ -1,6 +1,6 @@
 use super::Parser;
 use crate::error::ParseError;
-use crate::{AliasDeclaration, ExpectedContent, TypedName};
+use crate::{ASTExpression, AliasDeclaration, ExpectedContent, Type, TypedName};
 use crate::{Result, ast::GenericIdentifier};
 use common::pool::DedupPoolId;
 use common::{Span, Spanned, VisibilityModifier};
@@ -15,10 +15,10 @@ impl Parser<'_> {
                 TypedName {
                     name,
                     kind: Spanned::new(
-                        self.intern_type(GenericIdentifier {
+                        self.intern_type(Type::Plain(GenericIdentifier {
                             generic: SmallVec::new(),
                             identifier: self.intern("Self"),
-                        }),
+                        })),
                         span,
                     ),
                 },
@@ -71,26 +71,22 @@ impl Parser<'_> {
     }
 
     ///Parses a type.
-    pub fn parse_type(&mut self) -> Result<Spanned<DedupPoolId<GenericIdentifier>>> {
+    pub fn parse_type(&mut self) -> Result<Spanned<DedupPoolId<Type>>> {
         let token = self.peek()?;
         let start_span = token.span;
-
         if let TokenKind::LParen = &token.kind {
             self.eat()?;
             if let TokenKind::RParen = self.peek()?.kind {
                 let end_span = self.eat()?.span;
-                let id = self.intern_type(GenericIdentifier {
+                let id = self.intern_type(Type::Plain(GenericIdentifier {
                     identifier: self.intern("()"),
                     generic: smallvec![],
-                });
-                return Ok(Spanned {
-                    data: id,
-                    span: end_span,
-                });
+                }));
+                return Ok(end_span.make_spanned(id));
             }
             let mut types = smallvec![];
             loop {
-                types.push(self.parse_type()?.data);
+                types.push(self.parse_type()?);
                 match self.peek()?.kind {
                     TokenKind::Comma => {
                         self.eat()?;
@@ -105,12 +101,34 @@ impl Parser<'_> {
                 }
             }
             let span = start_span.merge_with(self.eat()?.span);
-            let ty = self.intern_type(GenericIdentifier {
+            let ty = self.intern_type(Type::Plain(GenericIdentifier {
                 identifier: self.intern("()"),
                 generic: types,
-            });
+            }));
 
-            return Ok(Spanned::new(ty, span));
+            return Ok(span.make_spanned(ty));
+        }
+        if self.peek()?.kind == TokenKind::LBracket {
+            enum TypeVariant {
+                Vector,
+                Array(DedupPoolId<ASTExpression>),
+            }
+            let start_span = self.eat()?.span;
+            let ty = if self.peek()?.kind == TokenKind::RBracket {
+                self.eat()?;
+                TypeVariant::Vector
+            } else {
+                let expr = self.parse_expression()?;
+                self.expect(&TokenKind::RBracket)?;
+                TypeVariant::Array(expr.data)
+            };
+            let inner_type = self.parse_type()?;
+            let span = start_span.merge_with(inner_type.span);
+            let out = match ty {
+                TypeVariant::Vector => self.intern_type(Type::Vector(inner_type.data)),
+                TypeVariant::Array(size) => self.intern_type(Type::Array(inner_type.data, size)),
+            };
+            return Ok(span.make_spanned(out));
         }
         let (ident, mut span) = self.expect_identifier()?;
         if let Token {
@@ -126,20 +144,20 @@ impl Parser<'_> {
                     span.end = end.end;
                     break;
                 }
-                let ty = self.parse_type()?.data;
+                let ty = self.parse_type()?;
                 generics.push(ty);
             }
-            let id = self.intern_type(GenericIdentifier {
+            let id = self.intern_type(Type::Plain(GenericIdentifier {
                 generic: generics,
                 identifier: ident,
-            });
-            Ok(Spanned { data: id, span })
+            }));
+            Ok(span.make_spanned(id))
         } else {
-            let id = self.intern_type(GenericIdentifier {
+            let id = self.intern_type(Type::Plain(GenericIdentifier {
                 generic: smallvec![],
                 identifier: ident,
-            });
-            Ok(Spanned { data: id, span })
+            }));
+            Ok(span.make_spanned(id))
         }
     }
 }

--- a/crates/parser/src/types.rs
+++ b/crates/parser/src/types.rs
@@ -1,12 +1,34 @@
+use std::ops::Deref;
+
 use super::Parser;
 use crate::error::ParseError;
-use crate::{ASTExpression, AliasDeclaration, ExpectedContent, Type, TypedName};
+use crate::{ASTExpression, AliasDeclaration, ExpectedContent, SymbolPointer, Type, TypedName};
 use crate::{Result, ast::GenericIdentifier};
 use common::pool::DedupPoolId;
 use common::{Span, Spanned, VisibilityModifier};
 use slynx_lexer::tokens::{Token, TokenKind};
 use smallvec::{SmallVec, smallvec};
 impl Parser<'_> {
+    pub fn type_name(&self, ty: DedupPoolId<Type>) -> SymbolPointer {
+        match &self.types[ty] {
+            Type::Plain(gi) => gi.identifier,
+            Type::Array(arr, len) => {
+                let name = self.symbols.get_name(self.type_name(*arr));
+                let len = match self.expressions.get(*len) {
+                    ASTExpression::IntLiteral(int) => int.to_string(),
+                    _ => unimplemented!(
+                        "This is not supported. An array type should contain a number inside it to determine its size. This is an expression due to the possibility of comptime, that is idealized. But at the moment only integer literals are accepted"
+                    ),
+                };
+                self.intern(&format!("[{len}]{name}"))
+            }
+            Type::Vector(inner) => self.intern(&format!(
+                "[]{}",
+                self.symbols.get_name(self.type_name(*inner))
+            )),
+        }
+    }
+
     ///Parses a typed name. A typed name is `name: type`, which is a name that contains a type
     pub fn parse_typedname(&mut self) -> Result<Spanned<TypedName>> {
         let (name, span) = self.expect_identifier()?;

--- a/crates/parser/src/types.rs
+++ b/crates/parser/src/types.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use super::Parser;
 use crate::error::ParseError;
 use crate::{ASTExpression, AliasDeclaration, ExpectedContent, SymbolPointer, Type, TypedName};

--- a/docs/arrays-vectors-slices.md
+++ b/docs/arrays-vectors-slices.md
@@ -1,0 +1,16 @@
+# Arrays, Vectors and Slices
+
+In the language there are going to be 3 types of basic collections: 
+Arrays which are represented by `[N]T` where N is a number, such as `[64]int`, `[128]bool`, etc. Vectors, which are represented by `[]T`, WITHOUT a numeric, which explicits that the size is not known, so, dynamic, so a vector.
+
+And lastly a slice which is T[:].
+
+## Creation
+For creating an array and a vector, the syntax is the same: `let a = [1uint8,2,3,4];` which by default will be an [N]T, in this case, `[4]uint8`. To represent it such as a vector it must be determined such as `let a: []uint8 = [1,2,3,4]`.
+Expressions prefixed by `[N]` understands that the next value is an array with N size, and the value of all the positions is the given value, such as `[44]0` is the same as [0,0,0,0,..44 0]. Same rule applies to vectors.
+
+## Slices
+Slices are operations that simply take a view into an array/vector. Slices then can be understood as references and local values. Due to so, the rules and the nature of the language, slices cannot be saved into structs(see memory-model.md)
+and can only be used within temporary things such as functions and parameters.
+
+To create a slice the idea is pretty simple: expression[range], where range is `N:M`, which slices from N to M `N:` which slices from N to the end, `:M` which slices start from the end, `:` which contains everything. The type then will be `[:]T`, which is a slice of T. A slice can be sliced as well.

--- a/docs/arrays-vectors-slices.md
+++ b/docs/arrays-vectors-slices.md
@@ -6,7 +6,10 @@ Arrays which are represented by `[N]T` where N is a number, such as `[64]int`, `
 And lastly a slice which is T[:].
 
 ## Creation
-For creating an array and a vector, the syntax is the same: `let a = [1uint8,2,3,4];` which by default will be an [N]T, in this case, `[4]uint8`. To represent it such as a vector it must be determined such as `let a: []uint8 = [1,2,3,4]`.
+For creating an array, the syntax is `[1uint8,2,3,4]`, which by default will be an `[N]T`, in this case, `[4]uint8`. To create a vector, the syntax is `{1uint8,2,3,4}`, whose type will be `[]T`(also `[]uint8` in this case). Note that a vector's size is not fixed, so the type of a vector literal is always `[]T`.
+
+An array literal is always an array, and a vector literal is always a vector; the expected type does not change this. So, to create a `[]int` out of values, use `let a: []int = {1,2,3,4}`, and to create a `[4]int`, use `let a: [4]int = [1,2,3,4]`.
+
 Expressions prefixed by `[N]` understands that the next value is an array with N size, and the value of all the positions is the given value, such as `[44]0` is the same as [0,0,0,0,..44 0]. Same rule applies to vectors.
 
 ## Slices

--- a/examples/arrays.syx
+++ b/examples/arrays.syx
@@ -1,0 +1,7 @@
+func main(){
+    let a: [4]int = [1,2,3,4];
+    let b = []int = [];
+    let c = a[:];
+    let d = a[1:]
+    let e = a[1:3];
+}

--- a/examples/arrays.syx
+++ b/examples/arrays.syx
@@ -1,7 +1,8 @@
 func main():void{
     let a: [4]int = [1,2,3,4];
-    let b: []int = [];
+    let b: []int = {};
     let c = a[1];
     let d = a[2];
     let e = a[33];
+    let f: []int = {1,2,3};
 }

--- a/examples/arrays.syx
+++ b/examples/arrays.syx
@@ -1,7 +1,7 @@
 func main():void{
     let a: [4]int = [1,2,3,4];
     let b: []int = [];
-    let c = a[:];
-    let d = a[1:]
-    let e = a[1:3];
+    let c = a[1];
+    let d = a[2];
+    let e = a[33];
 }

--- a/examples/arrays.syx
+++ b/examples/arrays.syx
@@ -1,6 +1,6 @@
-func main(){
+func main():void{
     let a: [4]int = [1,2,3,4];
-    let b = []int = [];
+    let b: []int = [];
     let c = a[:];
     let d = a[1:]
     let e = a[1:3];

--- a/src/compilation_context/errors/hir.rs
+++ b/src/compilation_context/errors/hir.rs
@@ -11,6 +11,7 @@ use crate::{
 impl SlynxContext {
     fn hir_error_to_string(&self, hir: &SlynxHir, err: &HIRError) -> String {
         match &err.kind {
+            HIRErrorKind::CouldntInfer => format!("Could not infer the type of expression"),
             HIRErrorKind::ComponentNotFound(name) => format!(
                 "Component named as '{}' could not be found",
                 hir.get_name(*name)

--- a/src/compilation_context/errors/hir.rs
+++ b/src/compilation_context/errors/hir.rs
@@ -11,6 +11,16 @@ use crate::{
 impl SlynxContext {
     fn hir_error_to_string(&self, hir: &SlynxHir, err: &HIRError) -> String {
         match &err.kind {
+            HIRErrorKind::UnexpectedType { expected, received } => {
+                let expected_name = hir.view(*expected).name();
+                let received_name = hir.view(*received).name();
+                format!(
+                    "Received an incorrect type. Expected {expected_name} instead, received type {received_name}"
+                )
+            }
+            HIRErrorKind::InvalidIndexing => {
+                format!("Expression cannot be indexed. It is not an array nor a vector.")
+            }
             HIRErrorKind::CouldntInfer => format!("Could not infer the type of expression"),
             HIRErrorKind::ComponentNotFound(name) => format!(
                 "Component named as '{}' could not be found",

--- a/src/compilation_context/errors/hir.rs
+++ b/src/compilation_context/errors/hir.rs
@@ -19,9 +19,9 @@ impl SlynxContext {
                 )
             }
             HIRErrorKind::InvalidIndexing => {
-                format!("Expression cannot be indexed. It is not an array nor a vector.")
+                "Expression cannot be indexed. It is not an array nor a vector.".to_string()
             }
-            HIRErrorKind::CouldntInfer => format!("Could not infer the type of expression"),
+            HIRErrorKind::CouldntInfer => "Could not infer the type of expression".to_string(),
             HIRErrorKind::ComponentNotFound(name) => format!(
                 "Component named as '{}' could not be found",
                 hir.get_name(*name)

--- a/src/compilation_context/mod.rs
+++ b/src/compilation_context/mod.rs
@@ -14,7 +14,7 @@ use slynx_hir::SlynxHir;
 use slynx_ir::SlynxIR;
 use slynx_lexer::{Lexer, TokenStream};
 use slynx_monomorphizer::Monomorphizer;
-use slynx_parser::{ASTExpression, ASTStatement, GenericIdentifier, Parser, Program};
+use slynx_parser::{ASTExpression, ASTStatement, Parser, Program, Type};
 
 pub use crate::compilation_context::errors::*;
 
@@ -130,7 +130,7 @@ pub struct GlobalPools {
     names: SymbolsModule<FrontendSymbol>,
     expressions: DedupPool<ASTExpression>,
     statements: DedupPool<ASTStatement>,
-    types: DedupPool<GenericIdentifier>,
+    types: DedupPool<Type>,
 }
 impl Default for GlobalPools {
     fn default() -> Self {

--- a/tests/arrays.rs
+++ b/tests/arrays.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+mod common;
+#[test]
+fn test_arrays_and_slices() {
+    let context = slynx::SlynxContext::new(
+        PathBuf::from("examples/arrays.syx"),
+        Some(common::STD_PATH.clone()),
+    )
+    .unwrap();
+    let _ = context.compile().unwrap();
+}


### PR DESCRIPTION
## Summary

This PR adds arrays and vectors to the language. Yet vectors are not able to do much, such as pushing, poping, etc, this initializes it in the language so it can be extended in the future. Slices are not idealized in this PR as well due to the lack of generics at the moment

## Scope

- Added Vector and Array types, as well as syntaxes
- Refactored IR to use dedup pools and changed the way ast handles 'types' which are more extensible now.

## Validation

```bash
make check
```

## Documentation Impact

- [ ] No documentation changes were needed
- [x] I updated the relevant documentation

## Checklist

- [x] My change is focused and reviewable
- [x] I performed a self-review
- [x] I added comments only where they help explain non-obvious logic
- [ ] I added or updated tests when applicable
- [x] I ran the validation listed above
- [ ] I used the existing issue/PR templates where applicable

## Related Issues

Closes #N/A
