### PR TITLE
Feature/nullables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "boxcar"
@@ -668,6 +668,7 @@ dependencies = [
 name = "slynx-ir"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "color-eyre",
  "common",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ parking_lot = "0.12.5"
 paste = "1.0.15"
 crossbeam-channel = "0.5.15"
 ordered-float = "5.3.0"
+bitflags = "2.13.1"
 
 [dependencies]
 clap={ version = "4.5.52", features = ["derive"] }
@@ -32,6 +33,7 @@ module_loader.path="./crates/module_loader"
 slynx-monomorphizer.path="./crates/monomorphizer"
 slynx-ir.path="./crates/ir"
 slynx-codegen.path="./crates/codegen"
+
 
 
 [workspace]

--- a/crates/codegen/src/expressions.rs
+++ b/crates/codegen/src/expressions.rs
@@ -209,10 +209,7 @@ impl Codegen {
                     unreachable!("Type of null should be a nullable");
                 };
                 let inner_ty = self.get_or_create_ir_type(&inner, hir, context.ir())?;
-                let ty = self.get_or_create_ir_type(&expression.ty, hir, context.ir())?;
-                let zeroed = context.emit(Opcode::Zeroed, smallvec![], inner_ty);
-                let true_value = context.emit_const(Operand::Bool(true), bool_ty);
-                context.emit(Opcode::Struct, smallvec![zeroed, true_value], ty)
+                context.emit(Opcode::Zeroed, smallvec![], inner_ty)
             }
             HirExpressionKind::ArrayIndex(arr, index) => {
                 let index = self.lower_expression(*index, hir, context)?;
@@ -298,13 +295,14 @@ impl Codegen {
                 else_branch,
             } => self.lower_if_expression(condition, then_branch, else_branch, hir, context)?,
         };
-        if !matches!(expression.kind, HirExpressionKind::Null)
-            && let HirType::Nullable(_) = &hir.types_module[expression.ty]
-        {
+        if let HirType::Nullable(_) = &hir.types_module[expression.ty] {
             let bool_ty = context.ir().bool_type();
-            let false_value = context.emit_const(Operand::Bool(false), bool_ty);
+            let bool_value = context.emit_const(
+                Operand::Bool(matches!(expression.kind, HirExpressionKind::Null)),
+                bool_ty,
+            );
             let nullable_type = self.get_or_create_ir_type(&expression.ty, hir, context.ir())?; //since its nullable, its certain for it to be an struct at this moment, so we can emit it like so
-            Ok(context.emit(Opcode::Struct, smallvec![value, false_value], nullable_type))
+            Ok(context.emit(Opcode::Struct, smallvec![value, bool_value], nullable_type))
         } else {
             Ok(value)
         }

--- a/crates/codegen/src/expressions.rs
+++ b/crates/codegen/src/expressions.rs
@@ -298,7 +298,13 @@ impl Codegen {
                 else_branch,
             } => self.lower_if_expression(condition, then_branch, else_branch, hir, context)?,
         };
-        Ok(value)
+        if let HirType::Nullable(_) = &hir.types_module[expression.ty] {
+            let false_value = context.emit_const(Operand::Bool(false), context.ir().bool_type());
+            let nullable_type = self.get_or_create_ir_type(&expression.ty, hir, context.ir())?; //since its nullable, its certain for it to be an struct at this moment, so we can emit it like so
+            Ok(context.emit(Opcode::Struct, smallvec![value, false_value], nullable_type))
+        } else {
+            Ok(value)
+        };
     }
 
     fn lower_if_expression(

--- a/crates/codegen/src/expressions.rs
+++ b/crates/codegen/src/expressions.rs
@@ -299,12 +299,13 @@ impl Codegen {
             } => self.lower_if_expression(condition, then_branch, else_branch, hir, context)?,
         };
         if let HirType::Nullable(_) = &hir.types_module[expression.ty] {
-            let false_value = context.emit_const(Operand::Bool(false), context.ir().bool_type());
+            let bool_ty = context.ir().bool_type();
+            let false_value = context.emit_const(Operand::Bool(false), bool_ty);
             let nullable_type = self.get_or_create_ir_type(&expression.ty, hir, context.ir())?; //since its nullable, its certain for it to be an struct at this moment, so we can emit it like so
             Ok(context.emit(Opcode::Struct, smallvec![value, false_value], nullable_type))
         } else {
             Ok(value)
-        };
+        }
     }
 
     fn lower_if_expression(

--- a/crates/codegen/src/expressions.rs
+++ b/crates/codegen/src/expressions.rs
@@ -298,7 +298,9 @@ impl Codegen {
                 else_branch,
             } => self.lower_if_expression(condition, then_branch, else_branch, hir, context)?,
         };
-        if let HirType::Nullable(_) = &hir.types_module[expression.ty] {
+        if !matches!(expression.kind, HirExpressionKind::Null)
+            && let HirType::Nullable(_) = &hir.types_module[expression.ty]
+        {
             let bool_ty = context.ir().bool_type();
             let false_value = context.emit_const(Operand::Bool(false), bool_ty);
             let nullable_type = self.get_or_create_ir_type(&expression.ty, hir, context.ir())?; //since its nullable, its certain for it to be an struct at this moment, so we can emit it like so

--- a/crates/codegen/src/expressions.rs
+++ b/crates/codegen/src/expressions.rs
@@ -1,6 +1,6 @@
 use common::{Operator, Spanned, pool::PoolId};
 use slynx_hir::{
-    DeclarationId, HirExpression, HirExpressionKind, HirFunctionDeclaration, HirStatement,
+    DeclarationId, HirExpression, HirExpressionKind, HirFunctionDeclaration, HirStatement, HirType,
     SlynxHir, SymbolPointer,
     id::{AnyDeclarationId, AnyLocalDeclarationId},
 };
@@ -204,11 +204,20 @@ impl Codegen {
         let expression = &hir[expr.data];
 
         let value = match &expression.kind {
+            HirExpressionKind::Null => {
+                let HirType::Nullable(inner) = hir.types_module[expression.ty].clone() else {
+                    unreachable!("Type of null should be a nullable");
+                };
+                let inner_ty = self.get_or_create_ir_type(&inner, hir, context.ir())?;
+                let ty = self.get_or_create_ir_type(&expression.ty, hir, context.ir())?;
+                let zeroed = context.emit(Opcode::Zeroed, smallvec![], inner_ty);
+                let true_value = context.emit_const(Operand::Bool(true), bool_ty);
+                context.emit(Opcode::Struct, smallvec![zeroed, true_value], ty)
+            }
             HirExpressionKind::ArrayIndex(arr, index) => {
                 let index = self.lower_expression(*index, hir, context)?;
-                let arr_type = hir.view(expr.data).ty();
                 let arr = self.lower_expression(*arr, hir, context)?;
-                let ty = self.get_or_create_ir_type(&arr_type, hir, context.ir())?;
+                let ty = self.get_or_create_ir_type(&expression.ty, hir, context.ir())?;
                 context.emit(Opcode::ArrayGet, smallvec![arr, index], ty)
             }
             HirExpressionKind::Array(arr) => {

--- a/crates/codegen/src/lib.rs
+++ b/crates/codegen/src/lib.rs
@@ -96,7 +96,6 @@ impl Codegen {
         self.lower_stylesheets(hir, &mut ir)?;
         Ok(ir)
     }
-
     /// Phase 0: Hoist declarations.
     fn hoist_declarations(&mut self, hir: &SlynxHir, ir: &mut SlynxIR) {
         for file in &hir.files {

--- a/crates/codegen/src/queries.rs
+++ b/crates/codegen/src/queries.rs
@@ -1,5 +1,5 @@
 use slynx_hir::{HirType, SlynxHir};
-use slynx_ir::{IRStructFlags, IRType, IRTypeId, SlynxIR};
+use slynx_ir::{IRStructFlags, IRTypeId, SlynxIR};
 
 use crate::{Codegen, CodegenError, TypeId};
 
@@ -43,18 +43,14 @@ impl Codegen {
             }
             HirType::Nullable(inner) => {
                 let name = hir.view(*inner).name();
-                let s = ir.create_struct(&format!("Nullable{name}"));
                 let inner_type = self.get_or_create_ir_type(&inner, hir, ir)?;
                 let boolean = ir.bool_type();
-                let IRType::Struct(strukt_id) = *ir.get_type(s) else {
-                    unreachable!("Expected type from ir.create_struct to be a struct one");
-                };
-                let strukt = ir.get_object_type_mut(strukt_id);
                 //struct {T, bool}
-                strukt.insert(IRStructFlags::NULLABLE);
-                strukt.insert_field(inner_type);
-                strukt.insert_field(boolean);
-                s
+                ir.create_struct_full(
+                    &format!("Nullable{name}"),
+                    vec![inner_type, boolean],
+                    IRStructFlags::NULLABLE,
+                )
             }
 
             _ => return Err(CodegenError::IRTypeNotRecognized(*ty)),

--- a/crates/codegen/src/queries.rs
+++ b/crates/codegen/src/queries.rs
@@ -1,5 +1,5 @@
 use slynx_hir::{HirType, SlynxHir};
-use slynx_ir::{IRType, IRTypeId, SlynxIR};
+use slynx_ir::{IRStructFlags, IRType, IRTypeId, SlynxIR};
 
 use crate::{Codegen, CodegenError, TypeId};
 
@@ -51,6 +51,7 @@ impl Codegen {
                 };
                 let strukt = ir.get_object_type_mut(strukt_id);
                 //struct {T, bool}
+                strukt.insert(IRStructFlags::NULLABLE);
                 strukt.insert_field(inner_type);
                 strukt.insert_field(boolean);
                 s

--- a/crates/codegen/src/queries.rs
+++ b/crates/codegen/src/queries.rs
@@ -1,9 +1,24 @@
+use common::pool::DedupPoolId;
 use slynx_hir::{HirType, SlynxHir};
 use slynx_ir::{IRStructFlags, IRTypeId, SlynxIR};
 
 use crate::{Codegen, CodegenError, TypeId};
 
 impl Codegen {
+    ///Generates a type name for use inside a Nullable struct name. Nested
+    ///containers are encoded recursively so the produced name carries no
+    ///special characters (e.g. `[4][]int` -> `ArrayVectorint4`).
+    fn nullable_inner_name(&self, ty: &DedupPoolId<HirType>, hir: &SlynxHir) -> String {
+        let view = hir.view(*ty);
+        if let Some(vec_inner) = view.is_vector() {
+            format!("Vector{}", self.nullable_inner_name(&vec_inner, hir))
+        } else if let Some((arr_inner, len)) = view.is_array() {
+            format!("Array{}{}", self.nullable_inner_name(&arr_inner, hir), len)
+        } else {
+            view.name()
+        }
+    }
+
     pub(crate) fn get_mapped_type(&self, ty: &TypeId) -> Option<IRTypeId> {
         self.types.get(ty).cloned()
     }
@@ -42,7 +57,7 @@ impl Codegen {
                 ir.create_vector(ty)
             }
             HirType::Nullable(inner) => {
-                let name = hir.view(*inner).name();
+                let name = self.nullable_inner_name(inner, hir);
                 let inner_type = self.get_or_create_ir_type(&inner, hir, ir)?;
                 let boolean = ir.bool_type();
                 //struct {T, bool}

--- a/crates/codegen/src/queries.rs
+++ b/crates/codegen/src/queries.rs
@@ -58,7 +58,7 @@ impl Codegen {
             }
             HirType::Nullable(inner) => {
                 let name = self.nullable_inner_name(inner, hir);
-                let inner_type = self.get_or_create_ir_type(&inner, hir, ir)?;
+                let inner_type = self.get_or_create_ir_type(inner, hir, ir)?;
                 let boolean = ir.bool_type();
                 //struct {T, bool}
                 ir.create_struct_full(

--- a/crates/codegen/src/queries.rs
+++ b/crates/codegen/src/queries.rs
@@ -1,5 +1,5 @@
 use slynx_hir::{HirType, SlynxHir};
-use slynx_ir::{IRTypeId, SlynxIR};
+use slynx_ir::{IRType, IRTypeId, SlynxIR};
 
 use crate::{Codegen, CodegenError, TypeId};
 
@@ -40,6 +40,20 @@ impl Codegen {
             HirType::Vector(t) => {
                 let ty = self.get_or_create_ir_type(t, hir, ir)?;
                 ir.create_vector(ty)
+            }
+            HirType::Nullable(inner) => {
+                let name = hir.view(*inner).name();
+                let s = ir.create_struct(&format!("Nullable{name}"));
+                let inner_type = self.get_or_create_ir_type(&inner, hir, ir)?;
+                let boolean = ir.bool_type();
+                let IRType::Struct(strukt_id) = *ir.get_type(s) else {
+                    unreachable!("Expected type from ir.create_struct to be a struct one");
+                };
+                let strukt = ir.get_object_type_mut(strukt_id);
+                //struct {T, bool}
+                strukt.insert_field(inner_type);
+                strukt.insert_field(boolean);
+                s
             }
 
             _ => return Err(CodegenError::IRTypeNotRecognized(*ty)),

--- a/crates/common/src/pool/mod.rs
+++ b/crates/common/src/pool/mod.rs
@@ -52,6 +52,33 @@ impl<T: Hash + Eq + Clone> DedupPool<T> {
             .get(id.as_raw() as usize)
             .expect("Expected to retrieve data from pool id originated from insert")
     }
+
+    ///Gets a mutable reference to the data that originated the given `id`.
+    ///
+    /// Note: mutating a value that was inserted into a dedup pool invalidates
+    /// its stored hash key. Only mutate values whose hash is stable under the
+    /// mutation (e.g. structs dedup'd by name) and never re-`insert` a value
+    /// that expects to be dedup'd on the mutated fields.
+    pub fn get_mut(&mut self, id: DedupPoolId<T>) -> &mut T {
+        self.inner
+            .get_mut(id.as_raw() as usize)
+            .expect("Expected to retrieve data from pool id originated from insert")
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.count()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    ///Iterates over all values stored on this pool, yielding their `id` and a reference to the data
+    pub fn iter(&self) -> impl Iterator<Item = (DedupPoolId<T>, &T)> {
+        self.inner
+            .iter()
+            .map(|(index, value)| (DedupPoolId::new(index as u32), value))
+    }
 }
 
 impl<T> Pool<T> {

--- a/crates/hir/src/builders/expression.rs
+++ b/crates/hir/src/builders/expression.rs
@@ -408,6 +408,25 @@ impl ExpressionBuilder {
     ) -> Result<Spanned<PoolId<HirExpression>>> {
         let expr = queue.get_expr(expression.data);
         let expr = match expr {
+            ASTExpression::Null => {
+                let ty = match expected {
+                    None => {
+                        return Err(HIRError::couldnt_infer(expression.span));
+                    }
+                    Some(ty) if let HirType::Nullable(_) = queue.hir.deref()[ty] => ty,
+                    Some(ty) => {
+                        return Err(HIRError::unexpected_type(
+                            ty,
+                            queue.hir.create_type(HirType::Nullable(ty)),
+                            expression.span,
+                        ));
+                    }
+                };
+                HirExpression {
+                    ty,
+                    kind: HirExpressionKind::Null,
+                }
+            }
             ASTExpression::IndexExpression(expr, range) => {
                 let expr = self.build_expression(queue, *expr, expected)?;
                 let after_index_type = {

--- a/crates/hir/src/builders/expression.rs
+++ b/crates/hir/src/builders/expression.rs
@@ -443,12 +443,12 @@ impl ExpressionBuilder {
                 let expr = self.build_expression(queue, *expr, expected)?;
                 let after_index_type = {
                     let expr_type = queue.hir[expr.data].ty;
-                    let actual_type = queue.hir.deref()[expr_type].clone();
-                    match actual_type {
-                        HirType::Vector(t) => t,
-                        HirType::Array(t, _) => t,
-                        _ => return Err(HIRError::invalid_indexing(expression.span)),
-                    }
+                    let actual_type = match &queue.hir.deref()[expr_type] {
+                        HirType::Vector(t) => t.clone(),
+                        HirType::Array(t, _) => t.clone(),
+                        _ => return Err(HIRError::invalid_indexing(expr_type, expression.span)),
+                    };
+                    queue.hir.create_type(HirType::Nullable(actual_type))
                 };
                 match range {
                     RangeType::NoRange(index) => {

--- a/crates/hir/src/builders/expression.rs
+++ b/crates/hir/src/builders/expression.rs
@@ -443,12 +443,11 @@ impl ExpressionBuilder {
                 let expr = self.build_expression(queue, *expr, expected)?;
                 let after_index_type = {
                     let expr_type = queue.hir[expr.data].ty;
-                    let actual_type = match &queue.hir.deref()[expr_type] {
-                        HirType::Vector(t) => t.clone(),
-                        HirType::Array(t, _) => t.clone(),
+                    match &queue.hir.deref()[expr_type] {
+                        HirType::Vector(t) => *t,
+                        HirType::Array(t, _) => *t,
                         _ => return Err(HIRError::invalid_indexing(expr_type, expression.span)),
-                    };
-                    queue.hir.create_type(HirType::Nullable(actual_type))
+                    }
                 };
                 match range {
                     RangeType::NoRange(index) => {

--- a/crates/hir/src/builders/expression.rs
+++ b/crates/hir/src/builders/expression.rs
@@ -120,6 +120,18 @@ impl ExpressionBuilder {
             queue.hir.view(expected).dereference(),
         ) {
             (a, b) if *a == *b => Ok(a.data),
+            (a, b)
+                if let Some(inner) = a.is_nullable()
+                    && inner == b.data =>
+            {
+                Ok(a.data)
+            }
+            (b, a)
+                if let Some(inner) = a.is_nullable()
+                    && inner == b.data =>
+            {
+                Ok(a.data)
+            }
             (received, expected) => Err(HIRError::unexpected_type(
                 received.data,
                 expected.data,

--- a/crates/hir/src/builders/function.rs
+++ b/crates/hir/src/builders/function.rs
@@ -119,7 +119,7 @@ impl HirFunctionBuilder {
         body: &[Spanned<DedupPoolId<ASTStatement>>],
     ) -> Result<ExpressionBuildResult> {
         let mut contains_return = false;
-        let mut statements = {
+        let statements = {
             let mut statements = Vec::new();
             let len = body.len();
 
@@ -143,7 +143,10 @@ impl HirFunctionBuilder {
         };
         let func_view = queue.hir.view(self.target);
 
-        if !contains_return && func_view.return_type() != queue.hir.create_type(HirType::Void) {
+        if !func_view.raw_declaration().external
+            && !contains_return
+            && func_view.return_type() != queue.hir.create_type(HirType::Void)
+        {
             return Err(HIRError::missing_return(func_view.raw_declaration().span));
         }
 

--- a/crates/hir/src/builders/function.rs
+++ b/crates/hir/src/builders/function.rs
@@ -3,7 +3,7 @@ use module_loader::FileId;
 use slynx_parser::{ASTStatement, FuncDeclaration};
 
 use crate::{
-    DeclarationId, HIRError, HirFunctionDeclaration, HirStatement, Result, SymbolPointer,
+    DeclarationId, HIRError, HirFunctionDeclaration, HirStatement, HirType, Result, SymbolPointer,
     VariableId,
     builders::{
         HirNode, HirQueueBuilder, PendantBody,
@@ -40,6 +40,7 @@ impl<'a> HirQueueBuilder<'a> {
                     visibility: f.visibility,
                     external: f.external,
                     attributes: Vec::new(),
+                    span: f.span,
                 };
                 let file = self.hir.get_or_create_file(node.entry);
                 file.create_function(decl)
@@ -117,23 +118,33 @@ impl HirFunctionBuilder {
         queue: &HirQueueBuilder<'_>,
         body: &[Spanned<DedupPoolId<ASTStatement>>],
     ) -> Result<ExpressionBuildResult> {
-        let mut statements = Vec::new();
-        let len = body.len();
-        for (i, statement) in body.iter().enumerate() {
-            if i + 1 == len {
-                // Last statement: build raw data, apply implicit return, then insert
-                let (data, span) = self.builder.build_statement_data(queue, statement)?;
-                let data = match data {
-                    HirStatement::Return { .. } => data,
-                    HirStatement::Expression { expr } => HirStatement::Return { expr: Some(expr) },
-                    _ => HirStatement::Return { expr: None },
+        let mut contains_return = false;
+        let mut statements = {
+            let mut statements = Vec::new();
+            let len = body.len();
+
+            for (i, statment) in body.iter().enumerate() {
+                if contains_return {
+                    break;
+                }
+                let (statment, span) = self.builder.build_statement_data(queue, statment)?;
+                let statment = if i + 1 == len
+                    && let HirStatement::Expression { expr } = statment
+                {
+                    HirStatement::Return { expr: Some(expr) }
+                } else {
+                    statment
                 };
-                let id = queue.hir.insert_statement(data);
-                statements.push(span.make_spanned(id));
-            } else {
-                let stmt = self.builder.build_statement(queue, statement)?;
-                statements.push(stmt);
+                contains_return = matches!(statment, HirStatement::Return { .. });
+                let stmt = queue.hir.insert_statement(statment);
+                statements.push(span.make_spanned(stmt));
             }
+            statements
+        };
+        let func_view = queue.hir.view(self.target);
+
+        if !contains_return && func_view.return_type() != queue.hir.create_type(HirType::Void) {
+            return Err(HIRError::missing_return(func_view.raw_declaration().span));
         }
 
         Ok(ExpressionBuildResult {

--- a/crates/hir/src/builders/mod.rs
+++ b/crates/hir/src/builders/mod.rs
@@ -163,6 +163,11 @@ impl HirNode<'_> {
                 let ty = self.hir.create_type(HirType::Vector(ty));
                 Ok((id, ty))
             }
+            Type::Nullable(nullable) => {
+                let (id, ty) = self.find_type(ty.span.make_spanned(*nullable))?;
+                let ty = self.hir.create_type(HirType::Nullable(ty));
+                Ok((id, ty))
+            }
         }
     }
     ///Gets the signature of the given `f` function. Asserting the id of the file it was generated is the given `file`.

--- a/crates/hir/src/builders/mod.rs
+++ b/crates/hir/src/builders/mod.rs
@@ -440,6 +440,7 @@ impl<'a> HirQueueBuilder<'a> {
                     visibility: obj_decl.visibility,
                     external: obj_decl.external,
                     attributes: Vec::new(),
+                    span: method.span,
                 };
                 let file = self.hir.get_or_create_file(obj_file_id);
                 file.create_function(decl)

--- a/crates/hir/src/error.rs
+++ b/crates/hir/src/error.rs
@@ -38,7 +38,7 @@ pub enum HIRErrorKind {
         received: DedupPoolId<HirType>,
     },
     ///Invalid indexing error occurs when the expression being indexed cannot be indexed. So 5[12] cannot be indexed, which then gives this error
-    InvalidIndexing,
+    InvalidIndexing(DedupPoolId<HirType>),
     ///Couldnt infer is an error when the type of something could not be inferred
     CouldntInfer,
     NotAComponent(SymbolPointer),
@@ -172,9 +172,9 @@ impl HIRError {
         }
     }
 
-    pub fn invalid_indexing(span: Span) -> Self {
+    pub fn invalid_indexing(expr_type: DedupPoolId<HirType>, span: Span) -> Self {
         Self {
-            kind: HIRErrorKind::InvalidIndexing,
+            kind: HIRErrorKind::InvalidIndexing(expr_type),
             span,
         }
     }
@@ -423,7 +423,7 @@ impl std::fmt::Display for HIRError {
             HIRErrorKind::UnexpectedType { .. } => {
                 write!(f, "Received mismatched types")
             }
-            HIRErrorKind::InvalidIndexing => write!(
+            HIRErrorKind::InvalidIndexing(_) => write!(
                 f,
                 "The given expression cannot be indexed because it is not an array nor vector"
             ),

--- a/crates/hir/src/error.rs
+++ b/crates/hir/src/error.rs
@@ -31,6 +31,8 @@ pub enum InvalidWriteReason {
 /// All possible error kinds that can occur during HIR generation.
 #[derive(Debug)]
 pub enum HIRErrorKind {
+    MissingReturn,
+
     UnexpectedType {
         expected: DedupPoolId<HirType>,
         received: DedupPoolId<HirType>,
@@ -163,6 +165,13 @@ pub enum HIRErrorKind {
 }
 
 impl HIRError {
+    pub fn missing_return(span: Span) -> Self {
+        Self {
+            kind: HIRErrorKind::MissingReturn,
+            span,
+        }
+    }
+
     pub fn invalid_indexing(span: Span) -> Self {
         Self {
             kind: HIRErrorKind::InvalidIndexing,
@@ -407,6 +416,10 @@ impl HIRError {
 impl std::fmt::Display for HIRError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.kind {
+            HIRErrorKind::MissingReturn => write!(
+                f,
+                "This function does not return at all, even though it should"
+            ),
             HIRErrorKind::UnexpectedType { .. } => {
                 write!(f, "Received mismatched types")
             }

--- a/crates/hir/src/helpers/views/declarations.rs
+++ b/crates/hir/src/helpers/views/declarations.rs
@@ -1,7 +1,10 @@
 use common::{FrontendSymbol, SymbolPointer, pool::DedupPoolId};
+use dashmap::mapref::one::MappedRef;
+use module_loader::FileId;
 
 use crate::{
     DeclarationId, HirFunctionDeclaration, HirType, VariableId,
+    file::HirFile,
     helpers::HirViewer,
     id::{AnyDeclarationId, AnyLocalDeclarationId},
 };
@@ -68,5 +71,8 @@ impl HirViewer<'_, DeclarationId<HirFunctionDeclaration>> {
     pub fn ty(&self) -> HirViewer<'_, DedupPoolId<HirType>> {
         let ty = self.hir.get_function(self.data).ty;
         self.new_with(ty)
+    }
+    pub fn raw_declaration(&self) -> MappedRef<'_, FileId, HirFile, HirFunctionDeclaration> {
+        self.hir.get_function(self.data)
     }
 }

--- a/crates/hir/src/helpers/views/types.rs
+++ b/crates/hir/src/helpers/views/types.rs
@@ -23,6 +23,10 @@ impl HirViewer<'_, DedupPoolId<HirType>> {
                 let name = self.new_with(*ty).name();
                 format!("{name}?")
             }
+            HirType::Array(ty, len) => {
+                format!("[{len}]{}", self.new_with(*ty).name())
+            }
+            HirType::Vector(ty) => format!("[]{}", self.new_with(*ty).name()),
             _ if let Some(func) = self.is_function() => {
                 let args = func
                     .arguments()

--- a/crates/hir/src/helpers/views/types.rs
+++ b/crates/hir/src/helpers/views/types.rs
@@ -19,6 +19,10 @@ impl HirViewer<'_, DedupPoolId<HirType>> {
             HirType::Int => "int".to_string(),
             HirType::Void => "void".to_string(),
             HirType::GenericComponent => "anycomponent".to_string(),
+            HirType::Nullable(ty) => {
+                let name = self.new_with(*ty).name();
+                format!("{name}?")
+            }
             _ if let Some(func) = self.is_function() => {
                 let args = func
                     .arguments()
@@ -45,6 +49,14 @@ impl HirViewer<'_, DedupPoolId<HirType>> {
             }
             _ if let Some(component) = self.is_component() => component.name().to_string(),
             t => unreachable!("Type {t:?} is not be able to have a name"),
+        }
+    }
+
+    pub fn is_nullable(&self) -> Option<DedupPoolId<HirType>> {
+        if let HirType::Nullable(inner) = self.hir.deref()[self.data] {
+            Some(inner)
+        } else {
+            None
         }
     }
 

--- a/crates/hir/src/model/declarations.rs
+++ b/crates/hir/src/model/declarations.rs
@@ -72,6 +72,7 @@ pub struct HirFunctionDeclaration {
     pub visibility: VisibilityModifier,
     pub external: bool,
     pub attributes: Vec<HirAttribute>,
+    pub span: Span,
 }
 
 #[derive(Debug)]

--- a/crates/hir/src/model/expression.rs
+++ b/crates/hir/src/model/expression.rs
@@ -357,6 +357,7 @@ pub enum HirExpressionKind {
 
     True,
     False,
+    Null,
 
     /// A tuple expression.
     ///

--- a/crates/hir/src/model/types.rs
+++ b/crates/hir/src/model/types.rs
@@ -266,6 +266,7 @@ pub struct StyleType {
 /// - [`crate::hir::model::ComponentProperty`] — Component property definitions
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum HirType {
+    Nullable(DedupPoolId<HirType>),
     Array(DedupPoolId<HirType>, usize),
     Vector(DedupPoolId<HirType>),
     /// A struct type with named fields.

--- a/crates/ir/Cargo.toml
+++ b/crates/ir/Cargo.toml
@@ -10,3 +10,4 @@ smallvec.workspace=true
 either = "1.15.0"
 petgraph.workspace=true
 paste = "1.0.15"
+bitflags.workspace=true

--- a/crates/ir/src/api.rs
+++ b/crates/ir/src/api.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Component, ComponentBuilder, ControlFlowGraph, Function, IRPointer, IRType, IRTypeId, SlynxIR,
-    builder::FunctionBuilder,
+    Component, ComponentBuilder, ControlFlowGraph, Function, IRPointer, IRStructFlags, IRType,
+    IRTypeId, SlynxIR, builder::FunctionBuilder,
 };
 
 impl SlynxIR {
@@ -15,6 +15,20 @@ impl SlynxIR {
     pub fn create_struct(&mut self, name: &str) -> IRTypeId {
         let name = self.strings.intern(name);
         self.create_empty_struct(name).0
+    }
+
+    /// Creates a named struct with the given `fields` and `flags`.
+    ///
+    /// Structs are dedup'd by name, so calling this multiple times with the same
+    /// `name` returns the same struct type regardless of `fields`.
+    pub fn create_struct_full(
+        &mut self,
+        name: &str,
+        fields: Vec<IRTypeId>,
+        flags: IRStructFlags,
+    ) -> IRTypeId {
+        let name = self.strings.intern(name);
+        self.types.create_named_struct(name, fields, flags)
     }
 
     /// Create a new empty function with the given name and return its pointer.

--- a/crates/ir/src/model/instruction.rs
+++ b/crates/ir/src/model/instruction.rs
@@ -137,6 +137,7 @@ pub enum Opcode {
     Vector,
     ///Gets the array on the given index. The first operand is the value to be indexed, and the second operand is the index
     ArrayGet,
+    Zeroed,
 }
 
 // ── Instruction ────────────────────────────────────────────────────────────
@@ -211,6 +212,13 @@ macro_rules! binop_ctor {
 }
 
 impl Instruction {
+    pub fn zeroed(ty: IRTypeId) -> Self {
+        Self {
+            opcode: Opcode::Zeroed,
+            value_type: ty,
+            operands: smallvec![],
+        }
+    }
     /// Build a call instruction.
     pub fn call(
         func: IRPointer<Function, 1>,

--- a/crates/ir/src/types/components.rs
+++ b/crates/ir/src/types/components.rs
@@ -1,5 +1,9 @@
-use crate::{IRTypeId, SymbolPointer};
+use std::hash::{Hash, Hasher};
+
+use common::pool::DedupPoolId;
 use smallvec::SmallVec;
+
+use crate::{IRTypeId, SymbolPointer};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum IRSpecializedComponentType {
@@ -14,8 +18,8 @@ pub struct IRComponent {
     pub(crate) children: SmallVec<[IRTypeId; 4]>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct IRComponentId(pub usize);
+///A reference to some component on the IR
+pub type IRComponentId = DedupPoolId<IRComponent>;
 
 impl IRComponent {
     pub fn new(name: SymbolPointer) -> Self {
@@ -47,5 +51,18 @@ impl IRComponent {
 
     pub fn children(&self) -> &[IRTypeId] {
         &self.children
+    }
+}
+
+impl PartialEq for IRComponent {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
+}
+impl Eq for IRComponent {}
+
+impl Hash for IRComponent {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
     }
 }

--- a/crates/ir/src/types/irtype.rs
+++ b/crates/ir/src/types/irtype.rs
@@ -1,8 +1,7 @@
 use common::pool::DedupPoolId;
 
 use crate::{
-    IRComponentId, IRSpecializedComponentType, IRStructId, Instruction,
-    types::functions::IRFunctionId,
+    IRComponentId, IRSpecializedComponentType, IRStructId, types::functions::IRFunctionId,
 };
 
 /// Logical identifier for a type inside IR type storage.

--- a/crates/ir/src/types/irtype.rs
+++ b/crates/ir/src/types/irtype.rs
@@ -1,7 +1,8 @@
 use common::pool::DedupPoolId;
 
 use crate::{
-    IRComponentId, IRSpecializedComponentType, IRStructId, types::functions::IRFunctionId,
+    IRComponentId, IRSpecializedComponentType, IRStructId, Instruction,
+    types::functions::IRFunctionId,
 };
 
 /// Logical identifier for a type inside IR type storage.

--- a/crates/ir/src/types/mod.rs
+++ b/crates/ir/src/types/mod.rs
@@ -37,9 +37,9 @@ pub type IRTypeId = DedupPoolId<IRType>;
 #[derive(Debug)]
 pub struct IRTypes {
     types: DedupPool<IRType>,
-    structs: Vec<IRStruct>,
+    structs: DedupPool<IRStruct>,
     functions: Vec<IRFunction>,
-    components: Vec<IRComponent>,
+    components: DedupPool<IRComponent>,
 }
 
 impl std::default::Default for IRTypes {
@@ -56,17 +56,17 @@ impl IRTypes {
         }
         Self {
             types,
-            structs: Vec::new(),
+            structs: DedupPool::new(),
             functions: Vec::new(),
-            components: Vec::new(),
+            components: DedupPool::new(),
         }
     }
 
-    pub fn structs(&self) -> &[IRStruct] {
-        &self.structs
+    pub fn structs(&self) -> impl Iterator<Item = &IRStruct> {
+        self.structs.iter().map(|(_, s)| s)
     }
-    pub fn components(&self) -> &[IRComponent] {
-        &self.components
+    pub fn components(&self) -> impl Iterator<Item = &IRComponent> {
+        self.components.iter().map(|(_, c)| c)
     }
 
     ///Checks if the provided `ty` is some variant of unsigned int
@@ -91,11 +91,11 @@ impl IRTypes {
 
     ///Gets a mutable referente to the type of the function with the provided `id`
     pub fn get_object_type(&self, id: IRStructId) -> &IRStruct {
-        &self.structs[id.0]
+        self.structs.get(id)
     }
     ///Gets a mutable referente to the type of the function with the provided `id`
     pub fn get_component_type(&self, id: IRComponentId) -> &IRComponent {
-        &self.components[id.0]
+        self.components.get(id)
     }
 
     ///Returns the IRTypeId of the `field_index`th field of the given struct/component type.
@@ -103,8 +103,8 @@ impl IRTypes {
     pub fn get_field_type(&self, ty: IRTypeId, field_index: u16) -> IRTypeId {
         let field_index = field_index as usize;
         match self.types.get(ty) {
-            IRType::Struct(sid) => self.structs[sid.0].get_fields()[field_index],
-            IRType::Component(cid) => self.components[cid.0].fields[field_index],
+            IRType::Struct(sid) => self.structs[*sid].get_fields()[field_index],
+            IRType::Component(cid) => self.components[*cid].fields[field_index],
             ref other => panic!(
                 "Expected struct or component type for field access, got {:?}",
                 other
@@ -118,11 +118,11 @@ impl IRTypes {
 
     ///Gets a mutable referente to the type of the function with the provided `id`
     pub fn get_object_type_mut(&mut self, id: IRStructId) -> &mut IRStruct {
-        &mut self.structs[id.0]
+        self.structs.get_mut(id)
     }
     ///Gets a mutable referente to the type of the function with the provided `id`
     pub fn get_component_type_mut(&mut self, id: IRComponentId) -> &mut IRComponent {
-        &mut self.components[id.0]
+        self.components.get_mut(id)
     }
 
     #[inline]
@@ -182,20 +182,29 @@ impl IRTypes {
     }
     ///Creates a new empty struct and returns its type ID
     pub(crate) fn create_empty_struct(&mut self, name: SymbolPointer) -> (IRTypeId, IRStructId) {
-        let sout = self.structs.len();
-        self.structs.push(IRStruct::new(Some(name)));
-        let struct_id = IRStructId(sout);
+        let struct_id = self.structs.insert(IRStruct::new(Some(name)));
         let out = self.insert_type(IRType::Struct(struct_id));
         (out, struct_id)
+    }
+    ///Creates a new struct fully formed with the given `fields` and `flags`,
+    ///dedup'd on its `name`, and returns its type ID
+    pub(crate) fn create_named_struct(
+        &mut self,
+        name: SymbolPointer,
+        fields: Vec<IRTypeId>,
+        flags: IRStructFlags,
+    ) -> IRTypeId {
+        let struct_id = self
+            .structs
+            .insert(IRStruct::new(Some(name)).with_flags(flags).with_fields(fields));
+        self.insert_type(IRType::Struct(struct_id))
     }
     ///Creates a new empty struct and returns its type ID
     pub(crate) fn create_empty_component(
         &mut self,
         name: SymbolPointer,
     ) -> (IRTypeId, IRComponentId) {
-        let sout = self.components.len();
-        self.components.push(IRComponent::new(name));
-        let component_id = IRComponentId(sout);
+        let component_id = self.components.insert(IRComponent::new(name));
         let out = self.insert_type(IRType::Component(component_id));
         (out, component_id)
     }
@@ -208,17 +217,11 @@ impl IRTypes {
         (out, func_id)
     }
     pub fn create_or_get_tuple(&mut self, elements: Vec<IRTypeId>) -> IRTypeId {
-        for (i, strukt) in self.structs.iter().enumerate() {
-            if strukt.get_fields() == elements {
-                return self.insert_type(IRType::Struct(IRStructId(i)));
-            }
-        }
         let mut s = IRStruct::new(None);
         for field in elements {
             s.insert_field(field);
         }
-        let sid = IRStructId(self.structs.len());
-        self.structs.push(s);
+        let sid = self.structs.insert(s);
         self.insert_type(IRType::Struct(sid))
     }
 }

--- a/crates/ir/src/types/mod.rs
+++ b/crates/ir/src/types/mod.rs
@@ -194,9 +194,11 @@ impl IRTypes {
         fields: Vec<IRTypeId>,
         flags: IRStructFlags,
     ) -> IRTypeId {
-        let struct_id = self
-            .structs
-            .insert(IRStruct::new(Some(name)).with_flags(flags).with_fields(fields));
+        let struct_id = self.structs.insert(
+            IRStruct::new(Some(name))
+                .with_flags(flags)
+                .with_fields(fields),
+        );
         self.insert_type(IRType::Struct(struct_id))
     }
     ///Creates a new empty struct and returns its type ID

--- a/crates/ir/src/types/structs.rs
+++ b/crates/ir/src/types/structs.rs
@@ -1,11 +1,23 @@
+use std::ops::{Deref, DerefMut};
+
+use bitflags::bitflags;
 use smallvec::SmallVec;
 
 use crate::{IRTypeId, SymbolPointer};
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, Default)]
+    pub struct IRStructFlags: u64 {
+        ///Flag to tell that this is struct represent a null type
+        const NULLABLE = 0b1;
+    }
+}
 
 #[derive(Debug, Default)]
 pub struct IRStruct {
     fields: SmallVec<[IRTypeId; 8]>,
     name: Option<SymbolPointer>,
+    flags: IRStructFlags,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -18,8 +30,10 @@ impl IRStruct {
         IRStruct {
             fields: SmallVec::new(),
             name,
+            flags: IRStructFlags::empty(),
         }
     }
+
     ///Inserts the provided `field` onto this struct's fields
     pub fn insert_field(&mut self, field: IRTypeId) {
         self.fields.push(field);
@@ -31,5 +45,17 @@ impl IRStruct {
 
     pub fn name(&self) -> Option<SymbolPointer> {
         self.name
+    }
+}
+
+impl Deref for IRStruct {
+    type Target = IRStructFlags;
+    fn deref(&self) -> &Self::Target {
+        &self.flags
+    }
+}
+impl DerefMut for IRStruct {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.flags
     }
 }

--- a/crates/ir/src/types/structs.rs
+++ b/crates/ir/src/types/structs.rs
@@ -1,28 +1,31 @@
-use std::ops::{Deref, DerefMut};
+use std::{
+    hash::{Hash, Hasher},
+    ops::{Deref, DerefMut},
+};
 
 use bitflags::bitflags;
+use common::pool::DedupPoolId;
 use smallvec::SmallVec;
 
 use crate::{IRTypeId, SymbolPointer};
 
 bitflags! {
-    #[derive(Debug, Clone, Copy, Default)]
+    #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
     pub struct IRStructFlags: u64 {
         ///Flag to tell that this is struct represent a null type
         const NULLABLE = 0b1;
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct IRStruct {
     fields: SmallVec<[IRTypeId; 8]>,
     name: Option<SymbolPointer>,
     flags: IRStructFlags,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 ///A reference to some struct on the IR
-pub struct IRStructId(pub usize);
+pub type IRStructId = DedupPoolId<IRStruct>;
 
 impl IRStruct {
     ///Creates a new empty struct
@@ -32,6 +35,18 @@ impl IRStruct {
             name,
             flags: IRStructFlags::empty(),
         }
+    }
+
+    ///Sets the flags of this struct, returning itself
+    pub fn with_flags(mut self, flags: IRStructFlags) -> Self {
+        self.flags = flags;
+        self
+    }
+
+    ///Sets the fields of this struct, returning itself
+    pub fn with_fields(mut self, fields: impl IntoIterator<Item = IRTypeId>) -> Self {
+        self.fields.extend(fields);
+        self
     }
 
     ///Inserts the provided `field` onto this struct's fields
@@ -45,6 +60,38 @@ impl IRStruct {
 
     pub fn name(&self) -> Option<SymbolPointer> {
         self.name
+    }
+}
+
+impl PartialEq for IRStruct {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.name, other.name) {
+            //Named structs are dedup'd by name alone. Their fields are allowed
+            //to be mutated after insertion (e.g. object structs that get their
+            //fields populated in a later lowering phase).
+            (Some(a), Some(b)) => a == b,
+            //Anonymous structs (tuples) are fully formed on insertion and are
+            //dedup'd by their contents.
+            (None, None) => self.fields == other.fields && self.flags == other.flags,
+            _ => false,
+        }
+    }
+}
+impl Eq for IRStruct {}
+
+impl Hash for IRStruct {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self.name {
+            Some(name) => {
+                0u8.hash(state);
+                name.hash(state);
+            }
+            None => {
+                1u8.hash(state);
+                self.fields.hash(state);
+                self.flags.hash(state);
+            }
+        }
     }
 }
 

--- a/crates/ir/src/visualize/formatter.rs
+++ b/crates/ir/src/visualize/formatter.rs
@@ -109,13 +109,12 @@ impl<'a> Formatter<'a> {
 
     pub fn format_types(&self) -> String {
         let mut out = String::new();
-        for (name, fields) in self
-            .types
-            .structs()
-            .iter()
-            .filter_map(|s| s.name().map(|name| (name, s.get_fields())))
-        {
-            let fields = fields
+        for strukt in self.types.structs() {
+            let Some(name) = strukt.name() else {
+                continue;
+            };
+            let fields = strukt
+                .get_fields()
                 .iter()
                 .map(|f| self.fmt_type(self.types.get_type(*f)))
                 .collect::<Vec<_>>()

--- a/crates/ir/src/visualize/formatter.rs
+++ b/crates/ir/src/visualize/formatter.rs
@@ -427,7 +427,7 @@ impl<'a> Formatter<'a> {
 
     pub fn format_instruction(&self, instr: &Instruction) -> String {
         match &instr.opcode {
-            Opcode::Zeroed => format!("zeroed"),
+            Opcode::Zeroed => "zeroed".to_string(),
             Opcode::ArrayGet => format!("array_get {}", self.fmt_operands(&instr.operands)),
             Opcode::Array => format!("[{}]", self.fmt_operands(&instr.operands)),
             Opcode::Vector => format!("vec[{}]", self.fmt_operands(&instr.operands)),

--- a/crates/ir/src/visualize/formatter.rs
+++ b/crates/ir/src/visualize/formatter.rs
@@ -428,6 +428,7 @@ impl<'a> Formatter<'a> {
 
     pub fn format_instruction(&self, instr: &Instruction) -> String {
         match &instr.opcode {
+            Opcode::Zeroed => format!("zeroed"),
             Opcode::ArrayGet => format!("array_get {}", self.fmt_operands(&instr.operands)),
             Opcode::Array => format!("[{}]", self.fmt_operands(&instr.operands)),
             Opcode::Vector => format!("vec[{}]", self.fmt_operands(&instr.operands)),

--- a/crates/lexer/src/tokens.rs
+++ b/crates/lexer/src/tokens.rs
@@ -55,6 +55,8 @@ pub enum TokenKind {
     Extern,
     #[token("return")]
     Return,
+    #[token("null")]
+    Null,
 
     // Multi-char operators (must come before single-char)
     #[token("&&")]
@@ -125,6 +127,8 @@ pub enum TokenKind {
     Comma,
     #[token(":")]
     Colon,
+    #[token("?")]
+    Question,
 
     // Literals
     #[regex(r"0x[0-9a-fA-F]+", |lex| i32::from_str_radix(&lex.slice()[2..], 16).ok())]

--- a/crates/module_loader/src/modules.rs
+++ b/crates/module_loader/src/modules.rs
@@ -104,10 +104,16 @@ impl<'a> Modules<'a> {
                 "[]{}",
                 self.loader.symbols.get_name(self.type_name(*inner))
             )),
-            Type::Nullable(inner) => self.loader.symbols.intern(&format!(
-                "{}?",
-                self.loader.symbols.get_name(self.type_name(*inner))
-            )),
+            Type::Nullable(inner) => {
+                let inner_name = self.loader.symbols.get_name(self.type_name(*inner));
+                match self.loader.types.get(*inner) {
+                    Type::Array(_, _) | Type::Vector(_) => {
+                        self.loader.symbols.intern(&format!("({inner_name})?"))
+                    }
+
+                    _ => self.loader.symbols.intern(&format!("{inner_name}?")),
+                }
+            }
         }
     }
 

--- a/crates/module_loader/src/modules.rs
+++ b/crates/module_loader/src/modules.rs
@@ -104,6 +104,10 @@ impl<'a> Modules<'a> {
                 "[]{}",
                 self.loader.symbols.get_name(self.type_name(*inner))
             )),
+            Type::Nullable(inner) => self.loader.symbols.intern(&format!(
+                "{}?",
+                self.loader.symbols.get_name(self.type_name(*inner))
+            )),
         }
     }
 

--- a/crates/parser/src/ast/expression.rs
+++ b/crates/parser/src/ast/expression.rs
@@ -32,6 +32,7 @@ pub enum RangeType {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum ASTExpression {
+    Null,
     IntLiteral(i32),
     StringLiteral(SymbolPointer),
     FloatLiteral(OrderedFloat<f32>),

--- a/crates/parser/src/ast/types.rs
+++ b/crates/parser/src/ast/types.rs
@@ -17,6 +17,7 @@ pub enum Type {
     Plain(GenericIdentifier),
     Array(DedupPoolId<Type>, DedupPoolId<ASTExpression>),
     Vector(DedupPoolId<Type>),
+    Nullable(DedupPoolId<Type>),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]

--- a/crates/parser/src/expr.rs
+++ b/crates/parser/src/expr.rs
@@ -578,7 +578,7 @@ impl Parser<'_> {
 
     /// Parses an expression, which is the top-level function for parsing any kind of expression. It starts by parsing a logical expression, which can include comparisons, additive, multiplicative, and primary expressions, and returns the resulting ASTExpression.
     pub fn parse_expression(&mut self) -> Result<Spanned<DedupPoolId<ASTExpression>>> {
-        let mut expr = match self.peek()?.kind {
+        let expr = match self.peek()?.kind {
             TokenKind::If => {
                 let span = self.eat()?.span;
                 self.parse_if(span)

--- a/crates/parser/src/expr.rs
+++ b/crates/parser/src/expr.rs
@@ -572,7 +572,7 @@ impl Parser<'_> {
 
     /// Parses an expression, which is the top-level function for parsing any kind of expression. It starts by parsing a logical expression, which can include comparisons, additive, multiplicative, and primary expressions, and returns the resulting ASTExpression.
     pub fn parse_expression(&mut self) -> Result<Spanned<DedupPoolId<ASTExpression>>> {
-        let expr = match self.peek()?.kind {
+        let mut expr = match self.peek()?.kind {
             TokenKind::If => {
                 let span = self.eat()?.span;
                 self.parse_if(span)
@@ -587,11 +587,10 @@ impl Parser<'_> {
             }
             _ => self.parse_logical(),
         }?;
-        if self.peek()?.kind == TokenKind::LBracket {
+        while self.peek()?.kind == TokenKind::LBracket {
             let span = self.eat()?.span;
-            self.parse_array_access(expr, span)
-        } else {
-            Ok(expr)
+            expr = self.parse_array_access(expr, span)?;
         }
+        Ok(expr)
     }
 }

--- a/crates/parser/src/expr.rs
+++ b/crates/parser/src/expr.rs
@@ -216,15 +216,21 @@ impl Parser<'_> {
     ) -> Result<Spanned<DedupPoolId<ASTExpression>>> {
         // Keep postfix parsing iterative so tuple access and chained field access
         // share the same code path.
-        while let Ok(token) = self.peek()
-            && token.kind == TokenKind::Dot
-        {
-            self.eat()?;
-            expr = self.parse_dot_postfix(expr)?;
+        loop {
+            match self.peek()?.kind {
+                TokenKind::Dot => {
+                    self.eat()?;
+                    expr = self.parse_dot_postfix(expr)?;
+                }
+                TokenKind::LBracket => {
+                    let span = self.eat()?.span;
+                    expr = self.parse_array_access(expr, span)?;
+                }
+                _ => break Ok(expr),
+            }
         }
-
-        Ok(expr)
     }
+
     ///Parses a postfix that comes after a '.'. This function initializes right after the '.'
     pub fn parse_dot_postfix(
         &mut self,
@@ -587,10 +593,7 @@ impl Parser<'_> {
             }
             _ => self.parse_logical(),
         }?;
-        while self.peek()?.kind == TokenKind::LBracket {
-            let span = self.eat()?.span;
-            expr = self.parse_array_access(expr, span)?;
-        }
+
         Ok(expr)
     }
 }

--- a/crates/parser/src/expr.rs
+++ b/crates/parser/src/expr.rs
@@ -280,6 +280,10 @@ impl Parser<'_> {
         } else {
             let current = self.eat()?;
             match current.kind {
+                TokenKind::Null => Ok(Spanned::new(
+                    self.intern_expression(ASTExpression::Null),
+                    current.span,
+                )),
                 TokenKind::Int(i) => Ok(Spanned::new(
                     self.intern_expression(ASTExpression::IntLiteral(i)),
                     current.span,

--- a/crates/parser/src/types.rs
+++ b/crates/parser/src/types.rs
@@ -24,6 +24,10 @@ impl Parser<'_> {
                 "[]{}",
                 self.symbols.get_name(self.type_name(*inner))
             )),
+            Type::Nullable(inner) => self.intern(&format!(
+                "{}?",
+                self.symbols.get_name(self.type_name(*inner))
+            )),
         }
     }
 
@@ -92,92 +96,106 @@ impl Parser<'_> {
 
     ///Parses a type.
     pub fn parse_type(&mut self) -> Result<Spanned<DedupPoolId<Type>>> {
-        let token = self.peek()?;
-        let start_span = token.span;
-        if let TokenKind::LParen = &token.kind {
-            self.eat()?;
-            if let TokenKind::RParen = self.peek()?.kind {
+        let ty = match self.peek()?.kind {
+            TokenKind::LBracket => {
+                enum TypeVariant {
+                    Vector,
+                    Array(DedupPoolId<ASTExpression>),
+                }
+                let start_span = self.eat()?.span;
+                let ty = if self.peek()?.kind == TokenKind::RBracket {
+                    self.eat()?;
+                    TypeVariant::Vector
+                } else {
+                    let expr = self.parse_expression()?;
+                    self.expect(&TokenKind::RBracket)?;
+                    TypeVariant::Array(expr.data)
+                };
+                let inner_type = self.parse_type()?;
+                let span = start_span.merge_with(inner_type.span);
+                let out = match ty {
+                    TypeVariant::Vector => self.intern_type(Type::Vector(inner_type.data)),
+                    TypeVariant::Array(size) => {
+                        self.intern_type(Type::Array(inner_type.data, size))
+                    }
+                };
+                span.make_spanned(out)
+            }
+            TokenKind::LParen if self.peek_at(1)?.kind == TokenKind::RParen => {
+                let start_span = self.eat()?.span;
                 let end_span = self.eat()?.span;
                 let id = self.intern_type(Type::Plain(GenericIdentifier {
                     identifier: self.intern("()"),
                     generic: smallvec![],
                 }));
-                return Ok(end_span.make_spanned(id));
+                end_span.make_spanned(id)
             }
-            let mut types = smallvec![];
-            loop {
-                types.push(self.parse_type()?);
-                match self.peek()?.kind {
-                    TokenKind::Comma => {
-                        self.eat()?;
-                    }
-                    TokenKind::RParen => break,
-                    _ => {
-                        return Err(ParseError::UnexpectedToken(
-                            self.eat()?,
-                            ExpectedContent::Raw("Was expecting ',' or ')' in tuple type".into()),
-                        ));
+            TokenKind::LParen => {
+                let start_span = self.eat()?.span;
+                let mut types = smallvec![];
+                loop {
+                    types.push(self.parse_type()?);
+                    match self.peek()?.kind {
+                        TokenKind::Comma => {
+                            self.eat()?;
+                        }
+                        TokenKind::RParen => break,
+                        _ => {
+                            return Err(ParseError::UnexpectedToken(
+                                self.eat()?,
+                                ExpectedContent::Raw(
+                                    "Was expecting ',' or ')' in tuple type".into(),
+                                ),
+                            ));
+                        }
                     }
                 }
+                let span = start_span.merge_with(self.eat()?.span);
+                let ty = self.intern_type(Type::Plain(GenericIdentifier {
+                    identifier: self.intern("()"),
+                    generic: types,
+                }));
+                span.make_spanned(ty)
             }
-            let span = start_span.merge_with(self.eat()?.span);
-            let ty = self.intern_type(Type::Plain(GenericIdentifier {
-                identifier: self.intern("()"),
-                generic: types,
-            }));
-
-            return Ok(span.make_spanned(ty));
-        }
-        if self.peek()?.kind == TokenKind::LBracket {
-            enum TypeVariant {
-                Vector,
-                Array(DedupPoolId<ASTExpression>),
-            }
-            let start_span = self.eat()?.span;
-            let ty = if self.peek()?.kind == TokenKind::RBracket {
-                self.eat()?;
-                TypeVariant::Vector
-            } else {
-                let expr = self.parse_expression()?;
-                self.expect(&TokenKind::RBracket)?;
-                TypeVariant::Array(expr.data)
-            };
-            let inner_type = self.parse_type()?;
-            let span = start_span.merge_with(inner_type.span);
-            let out = match ty {
-                TypeVariant::Vector => self.intern_type(Type::Vector(inner_type.data)),
-                TypeVariant::Array(size) => self.intern_type(Type::Array(inner_type.data, size)),
-            };
-            return Ok(span.make_spanned(out));
-        }
-        let (ident, mut span) = self.expect_identifier()?;
-        if let Token {
-            kind: TokenKind::Lt,
-            ..
-        } = self.peek()?
-        {
-            let mut generics = SmallVec::new();
-            self.eat()?;
-            loop {
-                if let TokenKind::Gt = self.peek()?.kind {
-                    let end = self.eat()?.span;
-                    span.end = end.end;
-                    break;
+            _ => {
+                let (ident, mut span) = self.expect_identifier()?;
+                if let Token {
+                    kind: TokenKind::Lt,
+                    ..
+                } = self.peek()?
+                {
+                    let mut generics = SmallVec::new();
+                    self.eat()?;
+                    loop {
+                        if let TokenKind::Gt = self.peek()?.kind {
+                            let end = self.eat()?.span;
+                            span.end = end.end;
+                            break;
+                        }
+                        let ty = self.parse_type()?;
+                        generics.push(ty);
+                    }
+                    let id = self.intern_type(Type::Plain(GenericIdentifier {
+                        generic: generics,
+                        identifier: ident,
+                    }));
+                    span.make_spanned(id)
+                } else {
+                    let id = self.intern_type(Type::Plain(GenericIdentifier {
+                        generic: smallvec![],
+                        identifier: ident,
+                    }));
+                    span.make_spanned(id)
                 }
-                let ty = self.parse_type()?;
-                generics.push(ty);
             }
-            let id = self.intern_type(Type::Plain(GenericIdentifier {
-                generic: generics,
-                identifier: ident,
-            }));
-            Ok(span.make_spanned(id))
+        };
+        if self.peek()?.kind == TokenKind::Question {
+            let end = self.eat()?.span;
+            let span = ty.span.merge_with(end);
+            let ty = self.intern_type(Type::Nullable(ty.data));
+            Ok(span.make_spanned(ty))
         } else {
-            let id = self.intern_type(Type::Plain(GenericIdentifier {
-                generic: smallvec![],
-                identifier: ident,
-            }));
-            Ok(span.make_spanned(id))
+            Ok(ty)
         }
     }
 }

--- a/crates/parser/src/types.rs
+++ b/crates/parser/src/types.rs
@@ -128,7 +128,7 @@ impl Parser<'_> {
                     identifier: self.intern("()"),
                     generic: smallvec![],
                 }));
-                end_span.make_spanned(id)
+                start_span.merge_with(end_span).make_spanned(id)
             }
             TokenKind::LParen => {
                 let start_span = self.eat()?.span;

--- a/crates/parser/src/types.rs
+++ b/crates/parser/src/types.rs
@@ -151,11 +151,15 @@ impl Parser<'_> {
                     }
                 }
                 let span = start_span.merge_with(self.eat()?.span);
-                let ty = self.intern_type(Type::Plain(GenericIdentifier {
-                    identifier: self.intern("()"),
-                    generic: types,
-                }));
-                span.make_spanned(ty)
+                if types.len() == 1 {
+                    types[0]
+                } else {
+                    let ty = self.intern_type(Type::Plain(GenericIdentifier {
+                        identifier: self.intern("()"),
+                        generic: types,
+                    }));
+                    span.make_spanned(ty)
+                }
             }
             _ => {
                 let (ident, mut span) = self.expect_identifier()?;

--- a/examples/nullables.syx
+++ b/examples/nullables.syx
@@ -1,0 +1,5 @@
+func main():void {
+    let a:int? = null;
+    let b: ([]int)? = null;
+    let c: int? = 15;
+}

--- a/src/compilation_context/errors/hir.rs
+++ b/src/compilation_context/errors/hir.rs
@@ -11,6 +11,9 @@ use crate::{
 impl SlynxContext {
     fn hir_error_to_string(&self, hir: &SlynxHir, err: &HIRError) -> String {
         match &err.kind {
+            HIRErrorKind::MissingReturn => {
+                format!("Function does not contain return, but its return type is NOT void")
+            }
             HIRErrorKind::UnexpectedType { expected, received } => {
                 let expected_name = hir.view(*expected).name();
                 let received_name = hir.view(*received).name();

--- a/src/compilation_context/errors/hir.rs
+++ b/src/compilation_context/errors/hir.rs
@@ -12,7 +12,7 @@ impl SlynxContext {
     fn hir_error_to_string(&self, hir: &SlynxHir, err: &HIRError) -> String {
         match &err.kind {
             HIRErrorKind::MissingReturn => {
-                format!("Function does not contain return, but its return type is NOT void")
+                "Function does not contain return, but its return type is NOT void".to_string()
             }
             HIRErrorKind::UnexpectedType { expected, received } => {
                 let expected_name = hir.view(*expected).name();

--- a/src/compilation_context/errors/hir.rs
+++ b/src/compilation_context/errors/hir.rs
@@ -21,8 +21,11 @@ impl SlynxContext {
                     "Received an incorrect type. Expected {expected_name} instead, received type {received_name}"
                 )
             }
-            HIRErrorKind::InvalidIndexing => {
-                "Expression cannot be indexed. It is not an array nor a vector.".to_string()
+            HIRErrorKind::InvalidIndexing(ty) => {
+                format!(
+                    "Expression cannot be indexed. Type is '{}', instead expected an array/vector type.",
+                    hir.view(*ty).name()
+                )
             }
             HIRErrorKind::CouldntInfer => "Could not infer the type of expression".to_string(),
             HIRErrorKind::ComponentNotFound(name) => format!(

--- a/tests/nullables.rs
+++ b/tests/nullables.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+mod common;
+#[test]
+fn test_nullable_types() {
+    let context = slynx::SlynxContext::new(
+        PathBuf::from("examples/nullables.syx"),
+        Some(common::STD_PATH.clone()),
+    )
+    .unwrap();
+    let _ = context.compile().unwrap();
+}

--- a/tests/type_checker.rs
+++ b/tests/type_checker.rs
@@ -26,7 +26,7 @@ fn rejects_function_without_return_value_for_non_void_return_type() {
     // The HIR builder does not yet validate that non-void functions
     // return a value; this test is a placeholder.
     compile_source("func main(): int { let x = 12; }")
-        .expect("return type checking is not yet in the builder");
+        .expect_err("expected function to fail due to not containing return type even though its return type is not void");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR implements Nullable types on the language, which now changed the return type of arrays/vector index expression.

## Scope

- Added Nullable types on the language
- Started adding metadata on structs on the IR
- Updated array/vector index return type to be from T to T?

## What is missing
- Checking when an nullable type is not a null value via conditionals, such as: 
```slynx
if nullable {/*here its 100% sure to be 'T' and not 'T?'*/}
```

## Validation

List the commands, tests, or manual checks you ran.

```bash
make check
```

## Documentation Impact

- [ ] No documentation changes were needed
- [x] I updated the relevant documentation

## Checklist

- [x] My change is focused and reviewable
- [x] I performed a self-review
- [x] I added comments only where they help explain non-obvious logic
- [x] I added or updated tests when applicable
- [x] I ran the validation listed above
- [x] I used the existing issue/PR templates where applicable

## Related Issues

Closes #N/A
