### PR TITLE
Fix/fix lazy generation

### DIFF
--- a/crates/hir/Cargo.toml
+++ b/crates/hir/Cargo.toml
@@ -17,3 +17,4 @@ parking_lot.workspace=true
 smallvec.workspace=true
 ordered-float.workspace=true
 crossbeam-channel.workspace=true
+either.workspace=true

--- a/crates/hir/src/builders/expression/calls.rs
+++ b/crates/hir/src/builders/expression/calls.rs
@@ -16,7 +16,11 @@ impl ExpressionBuilder {
         context: &TypeContext,
     ) -> Result<HirExpression> {
         let identifier = queue.get_plain_type(name);
-        let func = self.lookup_function(queue, name.span.make_spanned(identifier.identifier))?;
+        let func = self.lookup_function(
+            queue,
+            name.span.make_spanned(identifier.identifier),
+            self.file(),
+        )?;
         let func_viewer = queue.hir.view(func);
         let func_ty_view = func_viewer.ty();
         let func_real_type = func_ty_view

--- a/crates/hir/src/builders/expression/mod.rs
+++ b/crates/hir/src/builders/expression/mod.rs
@@ -188,8 +188,14 @@ impl ExpressionBuilder {
             }
 
             ASTExpression::FieldAccess { parent, field } => {
-                let parent = self.build_expression(queue, *parent, expected, context)?;
-                return self.build_field_access(queue, parent, *field, expression.span, context);
+                return self.build_access(
+                    queue,
+                    *parent,
+                    *field,
+                    expected,
+                    expression.span,
+                    context,
+                );
             }
             ASTExpression::TupleAccess { tuple, index } => self.build_tuple_access(
                 queue,

--- a/crates/hir/src/builders/expression/names.rs
+++ b/crates/hir/src/builders/expression/names.rs
@@ -1,4 +1,5 @@
 use common::{Span, Spanned};
+use module_loader::FileId;
 
 use crate::{
     DeclarationId, HIRError, HirExpression, HirExpressionKind, HirFunctionDeclaration,
@@ -33,10 +34,12 @@ impl ExpressionBuilder {
         }
     }
 
+    /// Tries to find a function by the given `name`, if not found on the HIR, tries to insert a function with the given name, if not able, then it returns an error.
     pub(super) fn lookup_function(
         &self,
-        queue: &HirQueueBuilder<'_>,
+        queue: &HirQueueBuilder,
         name: Spanned<SymbolPointer>,
+        requester: FileId,
     ) -> Result<DeclarationId<HirFunctionDeclaration>> {
         let identifier = name.data;
 
@@ -52,7 +55,7 @@ impl ExpressionBuilder {
         {
             Ok(func)
         } else {
-            Err(HIRError::name_unrecognized(identifier, name.span))
+            queue.find_function_named(name.data, requester, name.span)
         }
     }
 

--- a/crates/hir/src/builders/function.rs
+++ b/crates/hir/src/builders/function.rs
@@ -6,7 +6,7 @@ use crate::{
     DeclarationId, HIRError, HirFunctionDeclaration, HirStatement, HirType, Result, SymbolPointer,
     VariableId,
     builders::{
-        HirNode, HirQueueBuilder, PendantFunction,
+        HirQueueBuilder, PendantFunction,
         expression::{ExpressionBuildResult, ExpressionBuilder},
     },
     context::HirSymbol,
@@ -24,28 +24,28 @@ impl<'a> HirQueueBuilder<'a> {
     pub(crate) fn enqueue_function(
         &self,
         f: &'a FuncDeclaration,
-        node: HirNode<'_>,
+        owner: FileId,
     ) -> Result<DeclarationId<HirFunctionDeclaration>> {
-        let signature = node.get_signature_of_function(f)?;
+        let signature = self.get_node(owner).get_signature_of_function(f)?;
         let names = f.args.iter().map(|arg| arg.data.name.data).collect();
-        let id = self.hir.symbols_registry.get_or_insert_function(
-            HirSymbol::new(node.entry, f.name),
-            || {
-                let decl = HirFunctionDeclaration {
-                    name: f.name,
-                    generics: f.type_params.clone(),
-                    args: Default::default(),
-                    ty: signature,
-                    statements: Vec::new(),
-                    visibility: f.visibility,
-                    external: f.external,
-                    attributes: Vec::new(),
-                    span: f.span,
-                };
-                let file = self.hir.get_or_create_file(node.entry);
-                file.create_function(decl)
-            },
-        );
+        let id =
+            self.hir
+                .symbols_registry
+                .get_or_insert_function(HirSymbol::new(owner, f.name), || {
+                    let decl = HirFunctionDeclaration {
+                        name: f.name,
+                        generics: f.type_params.clone(),
+                        args: Default::default(),
+                        ty: signature,
+                        statements: Vec::new(),
+                        visibility: f.visibility,
+                        external: f.external,
+                        attributes: Vec::new(),
+                        span: f.span,
+                    };
+                    let file = self.hir.get_or_create_file(owner);
+                    file.create_function(decl)
+                });
 
         // Process attributes after the declaration is registered so we have the decl_id
         let decl_id =
@@ -70,9 +70,8 @@ impl<'a> HirQueueBuilder<'a> {
     }
 
     ///Finds a function with the given `name` and returns it's id. If not found on the `requester` it tries to find on other files the requester imports. If not recognized by any, then hoists it properly
-    #[allow(dead_code)]
     pub fn find_function_named(
-        &'a self,
+        &self,
         name: SymbolPointer,
         requester: FileId,
         span: Span,
@@ -84,8 +83,9 @@ impl<'a> HirQueueBuilder<'a> {
             Ok(func)
         } else if let Some(func) = self.hir.get_file(requester).find_function_with_name(name) {
             Ok(func)
-        } else if let Some((id, func)) = self.find_function_declaration(name, requester) {
-            self.enqueue_function(func, self.get_node(id))
+        } else if let Some((id, index)) = self.find_function_declaration(name, requester) {
+            let func = &self.modules.get_entry(id).func()[index];
+            self.enqueue_function(func, id)
         } else {
             Err(HIRError::name_unrecognized(name, span))
         }

--- a/crates/hir/src/builders/mod.rs
+++ b/crates/hir/src/builders/mod.rs
@@ -87,10 +87,6 @@ pub struct HirQueueBuilder<'a> {
     /// Single-threaded for now; see component-generation.md §8.
     // TODO(threading): replace with thread-local or DashMap<ThreadId, Vec<...>> when Rayon lands.
     pub signature_stack: RefCell<Vec<(FileId, SymbolPointer)>>,
-    /// Buffer for method bodies discovered during body processing, after the
-    /// main bodies channel has been closed.  `resolve_method` pushes here when
-    /// `bodies.try_send` fails, and `process` drains the buffer in a loop.
-    pub(crate) pending_bodies: RefCell<VecDeque<PendantFunction<'a>>>,
 }
 
 impl HirNode<'_> {
@@ -344,7 +340,6 @@ impl<'a> HirQueueBuilder<'a> {
             bodies_in_progress: DashSet::new(),
             signature_stack: RefCell::new(Vec::new()),
             signatures_in_progress: DashSet::new(),
-            pending_bodies: RefCell::new(VecDeque::new()),
         }
     }
     pub fn get_plain_type(&self, ty: Spanned<DedupPoolId<Type>>) -> &GenericIdentifier {
@@ -414,30 +409,6 @@ impl<'a> HirQueueBuilder<'a> {
 
     pub(crate) fn process(&self) -> Result<()> {
         loop {
-            // Drain bodies that were buffered during body processing (after the
-            // main channel sender was closed).  Processing one body may enqueue
-            // more via resolve_method, so we handle one at a time and re-enter.
-            {
-                let mut pending = self.pending_bodies.borrow_mut();
-                if let Some(body) = pending.pop_front() {
-                    drop(pending);
-                    let PendantFunction {
-                        func_id,
-                        body,
-                        argument_names,
-                        context,
-                    } = body;
-                    let mut builder = HirFunctionBuilder::new(func_id);
-                    for (idx, name) in argument_names.into_iter().enumerate() {
-                        builder.create_argument(&self, name, idx as u8);
-                    }
-                    let ExpressionBuildResult { statements, args } =
-                        builder.build_body(&self, body, &context)?;
-                    self.resolved_bodies.insert(func_id, (statements, args));
-                    continue;
-                }
-            }
-
             select! {
                 recv(self.bodies.receiver()) -> body => {
                     if let Ok(PendantFunction { func_id, body, argument_names, context }) = body {
@@ -447,6 +418,10 @@ impl<'a> HirQueueBuilder<'a> {
                         }
                         let ExpressionBuildResult { statements, args } = builder.build_body(&self, body, &context)?;
                         self.resolved_bodies.insert(func_id, (statements, args));
+
+                        if self.bodies.receiver().is_empty() {
+                            break;
+                        }
                     }else {
                         break;
                     }

--- a/crates/hir/src/builders/mod.rs
+++ b/crates/hir/src/builders/mod.rs
@@ -5,7 +5,7 @@ mod function;
 mod structs;
 pub(crate) mod styles;
 mod work_channel;
-use std::{cell::RefCell, ops::Deref};
+use std::{cell::RefCell, collections::VecDeque, ops::Deref};
 
 use common::{
     Spanned,
@@ -87,6 +87,10 @@ pub struct HirQueueBuilder<'a> {
     /// Single-threaded for now; see component-generation.md §8.
     // TODO(threading): replace with thread-local or DashMap<ThreadId, Vec<...>> when Rayon lands.
     pub signature_stack: RefCell<Vec<(FileId, SymbolPointer)>>,
+    /// Buffer for method bodies discovered during body processing, after the
+    /// main bodies channel has been closed.  `resolve_method` pushes here when
+    /// `bodies.try_send` fails, and `process` drains the buffer in a loop.
+    pub(crate) pending_bodies: RefCell<VecDeque<PendantFunction<'a>>>,
 }
 
 impl HirNode<'_> {
@@ -340,6 +344,7 @@ impl<'a> HirQueueBuilder<'a> {
             bodies_in_progress: DashSet::new(),
             signature_stack: RefCell::new(Vec::new()),
             signatures_in_progress: DashSet::new(),
+            pending_bodies: RefCell::new(VecDeque::new()),
         }
     }
     pub fn get_plain_type(&self, ty: Spanned<DedupPoolId<Type>>) -> &GenericIdentifier {
@@ -350,7 +355,7 @@ impl<'a> HirQueueBuilder<'a> {
             ),
         }
     }
-    pub(crate) fn close_bodies(&mut self) {
+    pub(crate) fn close_bodies(mut self) {
         self.bodies.close_sender();
     }
 
@@ -407,8 +412,32 @@ impl<'a> HirQueueBuilder<'a> {
         Ok(id)
     }
 
-    pub(crate) fn process(self) -> Result<()> {
+    pub(crate) fn process(&self) -> Result<()> {
         loop {
+            // Drain bodies that were buffered during body processing (after the
+            // main channel sender was closed).  Processing one body may enqueue
+            // more via resolve_method, so we handle one at a time and re-enter.
+            {
+                let mut pending = self.pending_bodies.borrow_mut();
+                if let Some(body) = pending.pop_front() {
+                    drop(pending);
+                    let PendantFunction {
+                        func_id,
+                        body,
+                        argument_names,
+                        context,
+                    } = body;
+                    let mut builder = HirFunctionBuilder::new(func_id);
+                    for (idx, name) in argument_names.into_iter().enumerate() {
+                        builder.create_argument(&self, name, idx as u8);
+                    }
+                    let ExpressionBuildResult { statements, args } =
+                        builder.build_body(&self, body, &context)?;
+                    self.resolved_bodies.insert(func_id, (statements, args));
+                    continue;
+                }
+            }
+
             select! {
                 recv(self.bodies.receiver()) -> body => {
                     if let Ok(PendantFunction { func_id, body, argument_names, context }) = body {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -203,20 +203,17 @@ impl<'a> SlynxHir<'a> {
         self.files.entry(id).or_insert_with(|| HirFile::new(id))
     }
 
-    fn generate(&'a self, modules: &'a Modules<'a>) -> Result<()> {
-        let mut builder = HirQueueBuilder::new(self, modules);
-        let entry = &modules.entries()[0];
-        for func in entry.func() {
-            let node = builder.get_node(entry.id);
-
-            builder.enqueue_function(func, node)?;
+    fn generate(&'a self, modules: &Modules) -> Result<()> {
+        let builder = HirQueueBuilder::new(self, modules);
+        {
+            let entry = &modules.entries()[0];
+            let main_symbol = self.intern_name("main");
+            if let Some(mainfunc) = entry.func().iter().find(|func| func.name == main_symbol) {
+                builder.enqueue_function(mainfunc, entry.id)?;
+            }
+            builder.process()?;
         }
-        for comp in entry.component() {
-            builder.enqueue_component(comp, entry.id)?;
-        }
-
         builder.close_bodies();
-        builder.process()?;
         Ok(())
     }
 }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -210,8 +210,8 @@ impl<'a> SlynxHir<'a> {
             let main_symbol = self.intern_name("main");
             if let Some(mainfunc) = entry.func().iter().find(|func| func.name == main_symbol) {
                 builder.enqueue_function(mainfunc, entry.id)?;
+                builder.process()?;
             }
-            builder.process()?;
         }
         builder.close_bodies();
         Ok(())


### PR DESCRIPTION
## Summary

This PR fixes errors related to lazyness. Now the code really is lazy and finds the functions accordingly to their usage.

## Scope

- Made hir generation process start by main function
- Updated queue to process things before closing bodies
- Updated queue to stop processing if after some processing, the queue is empty(nothing was previously inserted)

## Validation

List the commands, tests, or manual checks you ran.

```bash
make test
```

## Documentation Impact

- [ ] No documentation changes were needed
- [ ] I updated the relevant documentation

## Checklist

- [x] My change is focused and reviewable
- [x] I performed a self-review
- [x] I added comments only where they help explain non-obvious logic
- [ ] I added or updated tests when applicable
- [x] I ran the validation listed above
- [ ] I used the existing issue/PR templates where applicable

## Related Issues

Closes #N/A
