### PR TITLE
Fix/invalid self expression

### DIFF
--- a/crates/hir/src/builders/component.rs
+++ b/crates/hir/src/builders/component.rs
@@ -140,7 +140,7 @@ impl ComponentBuilder {
     pub fn new(target: DeclarationId<HirComponentDeclaration>) -> Self {
         Self {
             target,
-            builder: ExpressionBuilder::new(OwnerId::Component(target)),
+            builder: ExpressionBuilder::new(OwnerId::Component(target), None),
         }
     }
 

--- a/crates/hir/src/builders/expression/calls.rs
+++ b/crates/hir/src/builders/expression/calls.rs
@@ -1,19 +1,91 @@
-use common::{Spanned, pool::DedupPoolId};
+use common::{Span, Spanned, pool::DedupPoolId};
 use slynx_parser::{ASTExpression, Type, TypeContext};
 
 use crate::{
-    HIRError, HirExpression, HirExpressionKind, HirType, Result, builders::HirQueueBuilder,
+    DeclarationId, HIRError, HirExpression, HirExpressionKind, HirFunctionDeclaration, HirType,
+    Result, builders::HirQueueBuilder,
 };
 
 use super::ExpressionBuilder;
 
+///A descriptor for a function call expression.
+pub struct FunctionCallDescriptor<'a> {
+    ///The function that is being called
+    pub target: DeclarationId<HirFunctionDeclaration>,
+    ///The arguments passed to this function call
+    pub received_args: &'a [Spanned<DedupPoolId<ASTExpression>>],
+    ///The generic arguments passed to this function call
+    pub received_generics: &'a [Spanned<DedupPoolId<Type>>],
+    ///The type context for this function call
+    pub context: &'a TypeContext<'a>,
+}
+
 impl ExpressionBuilder {
+    pub(crate) fn build_call_for(
+        &mut self,
+        queue: &HirQueueBuilder<'_>,
+        descriptor: Spanned<FunctionCallDescriptor>,
+    ) -> Result<HirExpression> {
+        let func_viewer = queue.hir.view(descriptor.target);
+        let type_viewer = func_viewer.type_viewer();
+
+        let expected_args = type_viewer.arguments();
+
+        if expected_args.len() != descriptor.received_args.len() {
+            let name = func_viewer.name();
+            return Err(HIRError::invalid_funcall_arg_length(
+                name,
+                expected_args.len(),
+                descriptor.received_args.len(),
+                descriptor.span,
+            ));
+        }
+        let mut generics = queue
+            .get_node(self.file())
+            .resolve_call_generics(descriptor.received_generics, descriptor.context)?;
+        let args = {
+            descriptor
+                .received_args
+                .iter()
+                .zip(expected_args)
+                .map(|(arg, ty)| {
+                    let expected_ty = match queue.hir.view(*ty).raw() {
+                        HirType::GenericParam { index, .. } => {
+                            generics.get(*index as usize).cloned()
+                        }
+                        _ => None,
+                    };
+
+                    let expr =
+                        self.build_expression(queue, *arg, expected_ty, descriptor.context)?;
+                    if let HirType::GenericParam { index, .. } = queue.hir.view(*ty).raw()
+                        && let None = expected_ty
+                    {
+                        let expr_ty = queue.hir.view(expr.data).ty();
+                        generics.insert(*index as usize, expr_ty);
+                    }
+                    Ok(expr)
+                })
+                .collect::<Result<_>>()?
+        };
+        let ty = type_viewer.return_type();
+        Ok(HirExpression {
+            kind: HirExpressionKind::FunctionCall {
+                name: descriptor.target,
+                args,
+                generics,
+            },
+            ty,
+        })
+    }
+    /// Builds a function call expression for the function with the given `name`and `args`. This function might be changed to `build_call_for`
     pub(super) fn build_function_call(
         &mut self,
         queue: &HirQueueBuilder<'_>,
         name: Spanned<DedupPoolId<Type>>,
         args: &[Spanned<DedupPoolId<ASTExpression>>],
         context: &TypeContext,
+        span: Span,
     ) -> Result<HirExpression> {
         let identifier = queue.get_plain_type(name);
         let func = self.lookup_function(
@@ -21,53 +93,13 @@ impl ExpressionBuilder {
             name.span.make_spanned(identifier.identifier),
             self.file(),
         )?;
-        let func_viewer = queue.hir.view(func);
-        let func_ty_view = func_viewer.ty();
-        let func_real_type = func_ty_view
-            .is_function()
-            .expect("Function should have function type");
 
-        let expected_args = func_real_type.arguments();
-
-        if expected_args.len() != args.len() {
-            let func_name = identifier.identifier;
-            return Err(HIRError::invalid_funcall_arg_length(
-                func_name,
-                expected_args.len(),
-                args.len(),
-                name.span,
-            ));
-        }
-        let mut generics = queue
-            .get_node(self.file())
-            .resolve_call_generics(identifier, context)?;
-        let args = args
-            .iter()
-            .zip(expected_args)
-            .map(|(arg, ty)| {
-                let expected_ty = match queue.hir.view(*ty).raw() {
-                    HirType::GenericParam { index, .. } => generics.get(*index as usize).cloned(),
-                    _ => None,
-                };
-
-                let expr = self.build_expression(queue, *arg, expected_ty, context)?;
-                if let HirType::GenericParam { index, .. } = queue.hir.view(*ty).raw()
-                    && let None = expected_ty
-                {
-                    let expr_ty = queue.hir.view(expr.data).ty();
-                    generics.insert(*index as usize, expr_ty);
-                }
-                Ok(expr)
-            })
-            .collect::<Result<_>>()?;
-        let ty = func_real_type.return_type();
-        Ok(HirExpression {
-            kind: HirExpressionKind::FunctionCall {
-                name: func,
-                args,
-                generics,
-            },
-            ty,
-        })
+        let descriptor = FunctionCallDescriptor {
+            target: func,
+            received_args: args,
+            received_generics: &identifier.generic,
+            context,
+        };
+        self.build_call_for(queue, span.make_spanned(descriptor))
     }
 }

--- a/crates/hir/src/builders/expression/field_access.rs
+++ b/crates/hir/src/builders/expression/field_access.rs
@@ -1,13 +1,13 @@
 use common::{
-    pool::{DedupPoolId, PoolId},
     Span, Spanned, VisibilityModifier,
+    pool::{DedupPoolId, PoolId},
 };
 use module_loader::FileId;
 use slynx_parser::{ASTExpression, TypeContext};
 
 use crate::{
-    builders::HirQueueBuilder, helpers::Visible, HIRError, HirExpression, HirExpressionKind,
-    HirType, Result,
+    HIRError, HirExpression, HirExpressionKind, HirType, Result, builders::HirQueueBuilder,
+    helpers::Visible,
 };
 
 use super::ExpressionBuilder;
@@ -91,7 +91,7 @@ impl ExpressionBuilder {
             ASTExpression::Identifier(field_name) => {
                 let parent_ty = queue.hir[parent.data].ty;
                 let parent_view = queue.hir.view(parent_ty);
-                let resolved = parent_view.dereference();
+                let resolved = parent_view.concrete_type();
                 match resolved.is_struct() {
                     Some(view) => {
                         let (fields, field_types) = (view.fields(), view.field_types());

--- a/crates/hir/src/builders/expression/field_access.rs
+++ b/crates/hir/src/builders/expression/field_access.rs
@@ -6,7 +6,8 @@ use module_loader::FileId;
 use slynx_parser::{ASTExpression, TypeContext};
 
 use crate::{
-    HIRError, HirExpression, HirExpressionKind, HirType, Result, builders::HirQueueBuilder,
+    HIRError, HirExpression, HirExpressionKind, HirType, Result,
+    builders::{HirQueueBuilder, expression::calls::FunctionCallDescriptor},
     helpers::Visible,
 };
 
@@ -59,12 +60,25 @@ impl ExpressionBuilder {
                 unimplemented!("Constant values bound to types are not supported yet")
             }
             ASTExpression::FunctionCall { name, args } => {
-                let type_name = queue.type_name(name.data, &TypeContext::EMPTY);
-                if let Some(method) = queue.resolve_method(file_owner, ty, type_name)? {
-                    let call = self.build_function_call(queue, *name, args, context)?;
+                let method_name = queue.type_name(name.data, &TypeContext::EMPTY);
+                if let Some(method) = queue.resolve_method(file_owner, ty, method_name, span)? {
+                    let generics = {
+                        let plain = queue.get_plain_type(*name);
+                        &plain.generic
+                    };
+                    let call = self.build_call_for(
+                        queue,
+                        child.span.make_spanned(FunctionCallDescriptor {
+                            target: method,
+                            received_args: args,
+                            received_generics: generics,
+                            context,
+                        }),
+                    )?;
+
                     Ok(span.make_spanned(queue.hir.insert_expression(call)))
                 } else {
-                    Err(HIRError::static_method_not_found(type_name, span))
+                    Err(HIRError::static_method_not_found(method_name, span))
                 }
             }
             _ => Err(HIRError::invalid_type_access(span)),
@@ -171,7 +185,7 @@ impl ExpressionBuilder {
                 let name_sym = queue.type_name(name.data, &TypeContext::EMPTY);
                 let parent_ty = queue.hir[parent.data].ty;
                 let real_ty = queue.hir.view(parent_ty);
-                let deref = real_ty.dereference();
+                let deref = real_ty.concrete_type();
                 match deref.is_struct() {
                     None => return Err(HIRError::not_a_struct(deref.data, span)),
                     Some(view) => {
@@ -196,8 +210,12 @@ impl ExpressionBuilder {
 
                         let func_id = match func_id {
                             Some(id) => id,
-                            None if let Some(id) =
-                                queue.resolve_method(self.file(), deref.data, name_sym)? =>
+                            None if let Some(id) = queue.resolve_method(
+                                self.file(),
+                                deref.data,
+                                name_sym,
+                                span,
+                            )? =>
                             {
                                 id
                             }

--- a/crates/hir/src/builders/expression/mod.rs
+++ b/crates/hir/src/builders/expression/mod.rs
@@ -226,7 +226,7 @@ impl ExpressionBuilder {
                 queue.hir.create_binary_expression(lhs, rhs, *op, ty)
             }
             ASTExpression::FunctionCall { name, args } => {
-                self.build_function_call(queue, *name, args, context)?
+                self.build_function_call(queue, *name, args, context, expression.span)?
             }
             ASTExpression::If {
                 condition,

--- a/crates/hir/src/builders/expression/mod.rs
+++ b/crates/hir/src/builders/expression/mod.rs
@@ -62,13 +62,15 @@ impl DerefMut for VariablesManager {
 pub(crate) struct ExpressionBuilder {
     pub(crate) target: OwnerId,
     pub(crate) variables: VariablesManager,
+    pub(crate) self_type: Option<DedupPoolId<HirType>>,
 }
 
 impl ExpressionBuilder {
-    pub fn new(owner: OwnerId) -> Self {
+    pub fn new(owner: OwnerId, self_type: Option<DedupPoolId<HirType>>) -> Self {
         Self {
             target: owner,
             variables: VariablesManager::default(),
+            self_type,
         }
     }
 
@@ -147,7 +149,12 @@ impl ExpressionBuilder {
                 self.is_expression_able_to_write(queue, expr)
             }
             HirExpressionKind::Deref(inner)
-                if let HirType::MutableRef(_) = queue.hir.view(inner.data).ty_viewer().raw() =>
+                if queue
+                    .hir
+                    .view(inner.data)
+                    .ty_viewer()
+                    .is_mutable_ref()
+                    .is_some() =>
             {
                 Ok(())
             }

--- a/crates/hir/src/builders/expression/objects.rs
+++ b/crates/hir/src/builders/expression/objects.rs
@@ -10,6 +10,7 @@ use crate::{
 use super::ExpressionBuilder;
 
 impl ExpressionBuilder {
+
     pub(super) fn build_object(
         &mut self,
         queue: &HirQueueBuilder,
@@ -19,7 +20,12 @@ impl ExpressionBuilder {
         expected: Option<DedupPoolId<HirType>>,
         context: &TypeContext,
     ) -> Result<HirExpression> {
-        let (_, ty) = queue.get_node(self.file()).find_type(name, context)?;
+
+        let ty = if let Some(self_type) = &self.self_type {
+            queue.find_self_type(name.data, *self_type)
+        }else {
+            queue.get_node(self.file()).find_type(name, context)?.1
+        };
         let ty_view = queue.hir.view(ty);
         let deref = ty_view.dereference();
         let obj = deref

--- a/crates/hir/src/builders/function.rs
+++ b/crates/hir/src/builders/function.rs
@@ -65,6 +65,7 @@ impl<'a> HirQueueBuilder<'a> {
             func_id: id,
             body: &f.body,
             argument_names: names,
+            self_type: None
         });
         Ok(id)
     }
@@ -84,7 +85,7 @@ impl<'a> HirQueueBuilder<'a> {
         } else if let Some(func) = self.hir.get_file(requester).find_function_with_name(name) {
             Ok(func)
         } else if let Some((id, index)) = self.find_function_declaration(name, requester) {
-            let func = &self.modules.get_entry(id).func()[index];
+                let func = &self.modules.get_entry(id).func()[index];
             self.enqueue_function(func, id)
         } else {
             Err(HIRError::name_unrecognized(name, span))
@@ -93,10 +94,10 @@ impl<'a> HirQueueBuilder<'a> {
 }
 
 impl HirFunctionBuilder {
-    pub fn new(target: DeclarationId<HirFunctionDeclaration>) -> Self {
+    pub fn new(target: DeclarationId<HirFunctionDeclaration>, self_type: Option<DedupPoolId<HirType>>) -> Self {
         Self {
             target,
-            builder: ExpressionBuilder::new(OwnerId::Function(target)),
+            builder: ExpressionBuilder::new(OwnerId::Function(target), self_type),
             args: Vec::new(),
         }
     }

--- a/crates/hir/src/builders/mod.rs
+++ b/crates/hir/src/builders/mod.rs
@@ -58,6 +58,7 @@ pub(crate) struct PendantFunction<'a> {
     context: TypeContext<'a>,
     body: &'a [Spanned<DedupPoolId<ASTStatement>>],
     argument_names: Vec<SymbolPointer>,
+    self_type: Option<DedupPoolId<HirType>>
 }
 
 pub(crate) struct PendantComponent<'a> {
@@ -411,8 +412,8 @@ impl<'a> HirQueueBuilder<'a> {
         loop {
             select! {
                 recv(self.bodies.receiver()) -> body => {
-                    if let Ok(PendantFunction { func_id, body, argument_names, context }) = body {
-                        let mut builder = HirFunctionBuilder::new(func_id);
+                    if let Ok(PendantFunction { func_id, body, argument_names, context, self_type }) = body {
+                        let mut builder = HirFunctionBuilder::new(func_id, self_type);
                         for (idx, name) in argument_names.into_iter().enumerate() {
                             builder.create_argument(&self, name, idx as u8);
                         }

--- a/crates/hir/src/builders/mod.rs
+++ b/crates/hir/src/builders/mod.rs
@@ -58,7 +58,7 @@ pub(crate) struct PendantFunction<'a> {
     context: TypeContext<'a>,
     body: &'a [Spanned<DedupPoolId<ASTStatement>>],
     argument_names: Vec<SymbolPointer>,
-    self_type: Option<DedupPoolId<HirType>>
+    self_type: Option<DedupPoolId<HirType>>,
 }
 
 pub(crate) struct PendantComponent<'a> {
@@ -250,11 +250,10 @@ impl HirNode<'_> {
     ///substitutes with concrete types.
     pub fn resolve_call_generics(
         &self,
-        identifier: &GenericIdentifier,
+        generics: &[Spanned<DedupPoolId<Type>>],
         context: &TypeContext,
     ) -> Result<Vec<DedupPoolId<HirType>>> {
-        identifier
-            .generic
+        generics
             .iter()
             .map(|ty| self.find_type(*ty, context).map(|(_, ty)| ty))
             .collect()

--- a/crates/hir/src/builders/structs.rs
+++ b/crates/hir/src/builders/structs.rs
@@ -150,6 +150,7 @@ impl<'a> HirQueueBuilder<'a> {
                 func_id: decl_id,
                 body: &method.body,
                 argument_names: arg_names,
+                self_type: Some(struct_ty),
             });
         }
 

--- a/crates/hir/src/builders/structs.rs
+++ b/crates/hir/src/builders/structs.rs
@@ -1,10 +1,10 @@
-use common::pool::DedupPoolId;
+use common::{Span, Spanned, pool::DedupPoolId};
 use module_loader::{ASTType, ASTTypeKind, FileId};
-use slynx_parser::{ASTExpression, Type, TypeContext};
+use slynx_parser::{ASTExpression, ObjectMethod, Type, TypeContext};
 
 use crate::{
-    DeclarationId, HirFunctionDeclaration, HirQueueBuilder, HirType, PendantFunction, Result,
-    SymbolPointer, context::HirSymbol,
+    DeclarationId, HIRError, HirFunctionDeclaration, HirQueueBuilder, HirType, PendantFunction,
+    Result, SymbolPointer, context::HirSymbol,
 };
 
 impl<'a> HirQueueBuilder<'a> {
@@ -51,15 +51,17 @@ impl<'a> HirQueueBuilder<'a> {
     /// Lazily resolves a method on a struct type. Looks up the `ObjectDeclaration`
     /// from the AST, creates the function declaration, registers it as a method
     /// on the type, and enqueues the body for processing.
+    /// Returns the `DeclarationId` of the function declaration, if one was created, otherwise returns Ok(None).
     pub(crate) fn resolve_method(
         &self,
         file_id: FileId,
         struct_ty: DedupPoolId<HirType>,
         method_name: SymbolPointer,
+        span: Span,
     ) -> Result<Option<DeclarationId<HirFunctionDeclaration>>> {
         let struct_id = match self.hir.types_module[struct_ty] {
             HirType::Struct(id) => id,
-            _ => return Ok(None),
+            _ => return Err(HIRError::not_a_struct(struct_ty, span)),
         };
         let struct_name = self.hir.get_struct_name(struct_id);
 
@@ -69,43 +71,35 @@ impl<'a> HirQueueBuilder<'a> {
                 owner,
                 content: ASTTypeKind::Struct(decl),
             }) => (owner, decl),
-            _ => return Ok(None),
+            _ => return Err(HIRError::not_a_struct(struct_ty, span)),
         };
 
         let method = obj_decl
             .methods
             .iter()
-            .find(|m| m.method_name == method_name);
-
-        let Some(method) = method else {
-            return Ok(None);
-        };
+            .find(|m| m.method_name == method_name)
+            .ok_or(HIRError::method_not_found(method_name, span))?;
 
         let self_sym = self.hir.intern_name("Self");
         let node = self.get_node(file_id);
 
-        let mut args = Vec::with_capacity(method.arguments.len());
         let context = TypeContext::new(&method.type_params);
-        for arg in &method.arguments {
-            let ty = if let Some(name) = self.modules.referenced_name(arg.data.kind.data)
+
+        let find_self_type = |ty: Spanned<DedupPoolId<Type>>| {
+            if let Some(name) = self.modules.referenced_name(ty.data)
                 && name == self_sym
             {
-                self.find_self_type(arg.data.kind.data, struct_ty)
+                Ok(self.find_self_type(ty.data, struct_ty))
             } else {
-                let (_, ty) = node.find_type(arg.data.kind, &context)?;
-                ty
-            };
-            args.push(ty);
-        }
-
-        let return_type = if let Some(name) = self.modules.referenced_name(method.return_type.data)
-            && name == self_sym
-        {
-            self.find_self_type(method.return_type.data, struct_ty)
-        } else {
-            let (_, ty) = node.find_type(method.return_type, &context)?;
-            ty
+                node.find_type(ty, &context).map(|v| v.1)
+            }
         };
+        let args = method
+            .arguments
+            .iter()
+            .map(|arg| find_self_type(arg.data.kind))
+            .collect::<Result<Vec<_>>>()?;
+        let return_type = find_self_type(method.return_type)?;
 
         let func_ty = self.hir.create_function_type(args, return_type);
 
@@ -114,13 +108,14 @@ impl<'a> HirQueueBuilder<'a> {
             self.hir.get_name(method_name),
             self.hir.get_name(struct_name),
         );
+
         let mangled_symbol = self.hir.intern_name(&mangled);
 
         let decl_id = self.hir.symbols_registry.get_or_insert_function(
             HirSymbol::new(obj_file_id, mangled_symbol),
             || {
                 let decl = HirFunctionDeclaration {
-                    name: method_name,
+                    name: mangled_symbol,
                     generics: method.type_params.clone(),
                     args: Default::default(),
                     ty: func_ty,

--- a/crates/hir/src/error.rs
+++ b/crates/hir/src/error.rs
@@ -38,6 +38,7 @@ pub enum NotMutableReason {
 /// All possible error kinds that can occur during HIR generation.
 #[derive(Debug)]
 pub enum HIRErrorKind {
+    MethodNotFound(SymbolPointer),
     StaticMethodNotFound(SymbolPointer),
     InvalidTypeAccess,
     ExpressionNotMutable(NotMutableReason),
@@ -199,6 +200,13 @@ pub enum HIRErrorKind {
 }
 
 impl HIRError {
+    pub fn method_not_found(name: SymbolPointer, span: Span) -> Self {
+        Self {
+            kind: HIRErrorKind::MethodNotFound(name),
+            span,
+        }
+    }
+
     pub fn static_method_not_found(name: SymbolPointer, span: Span) -> Self {
         Self {
             kind: HIRErrorKind::StaticMethodNotFound(name),
@@ -520,6 +528,9 @@ impl HIRError {
 impl std::fmt::Display for HIRError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.kind {
+            HIRErrorKind::MethodNotFound(_) => {
+                write!(f, "Method not found")
+            }
             HIRErrorKind::StaticMethodNotFound(_) => {
                 write!(f, "Static method not found")
             }

--- a/crates/hir/src/helpers/views/functions.rs
+++ b/crates/hir/src/helpers/views/functions.rs
@@ -1,6 +1,8 @@
 use common::pool::DedupPoolId;
 
-use crate::{FunctionType, HirType, helpers::HirViewer};
+use crate::{
+    DeclarationId, FunctionType, HirFunctionDeclaration, HirType, SymbolPointer, helpers::HirViewer,
+};
 
 impl HirViewer<'_, DedupPoolId<FunctionType>> {
     pub fn arguments(&self) -> &[DedupPoolId<HirType>] {
@@ -8,5 +10,34 @@ impl HirViewer<'_, DedupPoolId<FunctionType>> {
     }
     pub fn return_type(&self) -> DedupPoolId<HirType> {
         self.hir.types_module[self.data].ret
+    }
+}
+
+impl HirViewer<'_, DeclarationId<HirFunctionDeclaration>> {
+    pub fn name(&self) -> SymbolPointer {
+        self.hir.get_function(self.data).name
+    }
+    pub fn generic(&self, generic: usize) -> Option<SymbolPointer> {
+        self.hir
+            .get_function(self.data)
+            .generics
+            .get(generic)
+            .cloned()
+    }
+    pub fn generic_count(&self) -> usize {
+        self.hir.get_function(self.data).generics.len()
+    }
+    pub fn type_viewer(&self) -> HirViewer<'_, DedupPoolId<FunctionType>> {
+        let ty = self.hir.get_function(self.data).ty;
+        let viewer = self.hir.view(ty);
+        if let Some(func_viewer) = viewer.is_function() {
+            let data = func_viewer.data;
+            HirViewer {
+                hir: self.hir,
+                data,
+            }
+        } else {
+            panic!("Type of function is not HirType::Function. internal error during hir creation");
+        }
     }
 }

--- a/crates/hir/src/helpers/views/types.rs
+++ b/crates/hir/src/helpers/views/types.rs
@@ -149,6 +149,33 @@ impl HirViewer<'_, DedupPoolId<HirType>> {
         }
         self.new_with(data)
     }
+
+    ///Returns the concrete type of this type. If this type is a reference type(a type that maps to another type), this function will find the concrete type, and if the concrete type is a reference(&T/&mut T), this function will retrieve T
+    ///Its then different from [`dereference`] which will return the type by remapping it, but yet making &T/&mut T a possible return case, where this one gets the concrete T type being used. This is mainly useful for checks where
+    ///you do wanna see the concrete type that is being dealed, even though its abstracted by something, such, as said above, &T.
+    ///Same thing to track nullable types.
+    ///
+    ///```
+    ///let strukt_type = hir.create_struct_type();
+    ///let ty = hir.create_type(HirType::Nullable(strukt_type));
+    ///let type_view = type_view.concrete_type();
+    ///assert_eq!(type_view.data, strukt_type);
+    ///```
+    ///
+    pub fn concrete_type(&self) -> HirViewer<'_, DedupPoolId<HirType>> {
+        let mut data = self.data;
+        loop {
+            match self.hir.deref()[data] {
+                HirType::Nullable(rf)
+                | HirType::ImutableRef(rf)
+                | HirType::MutableRef(rf)
+                | HirType::Reference { rf, .. } => data = rf,
+                _ => break,
+            }
+        }
+        self.new_with(data)
+    }
+
     pub fn is_ref(&self) -> bool {
         matches!(
             self.hir.deref()[self.data],

--- a/crates/ir/src/types/mod.rs
+++ b/crates/ir/src/types/mod.rs
@@ -101,10 +101,11 @@ impl IRTypes {
     ///Returns the IRTypeId of the `field_index`th field of the given struct/component type.
     ///Panics if `ty` is not a Struct or Component, or if `field_index` is out of bounds.
     pub fn get_field_type(&self, ty: IRTypeId, field_index: u16) -> IRTypeId {
-        let field_index = field_index as usize;
+        let index = field_index as usize;
         match self.types.get(ty) {
-            IRType::Struct(sid) => self.structs[*sid].get_fields()[field_index],
-            IRType::Component(cid) => self.components[*cid].fields[field_index],
+            IRType::Struct(sid) => self.structs[*sid].get_fields()[index],
+            IRType::Component(cid) => self.components[*cid].fields[index],
+            IRType::Pointer(ptr) => self.get_field_type(*ptr, field_index),
             ref other => panic!(
                 "Expected struct or component type for field access, got {:?}",
                 other


### PR DESCRIPTION
## Summary

This PR fixes the implementation of 'Self' types and struct expression, and 'self' expressions on methods and static methods

## Scope

- Fixed errors related to how Self and self are read on hir

## Validation

List the commands, tests, or manual checks you ran.

```bash
cargo test --test obj_methods 
```

## Documentation Impact

- [ ] No documentation changes were needed
- [x] I updated the relevant documentation

## Checklist

- [x] My change is focused and reviewable
- [x] I performed a self-review
- [ ] I added comments only where they help explain non-obvious logic
- [ ] I added or updated tests when applicable
- [x] I ran the validation listed above
- [ ] I used the existing issue/PR templates where applicable

## Related Issues

Closes #N/A
