### PR TITLE
Refactor/hir builder descriptors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ paste = "1.0.15"
 crossbeam-channel = "0.5.15"
 ordered-float = "5.3.0"
 bitflags = "2.13.1"
+either = "1.18.0"
 
 [dependencies]
 clap={ version = "4.5.52", features = ["derive"] }

--- a/crates/codegen/src/instructions.rs
+++ b/crates/codegen/src/instructions.rs
@@ -57,7 +57,7 @@ impl Codegen {
                         if let Some(ty) = hir.view(inner.data).ty_viewer().is_mutable_ref()
                             && let Some(s) = ty.is_struct()
                         {
-                            s.field_types()[*field_index as usize]
+                            s.field_types()[*field_index]
                         } else {
                             panic!(
                                 "This shit should be a reference type, and since its inside a field access, a reference to a struct"
@@ -67,7 +67,7 @@ impl Codegen {
                     let ty = self.get_or_create_ir_type(&field_type, hir, context.ir())?;
                     context.ir().pointer_type(ty)
                 };
-                let parent = self.lower_expression(*&inner, hir, context)?;
+                let parent = self.lower_expression(inner, hir, context)?;
                 let parent = context.emit(
                     Opcode::FieldRef(*field_index as u16),
                     smallvec![parent],

--- a/crates/hir/src/builders/component.rs
+++ b/crates/hir/src/builders/component.rs
@@ -5,7 +5,10 @@ use slynx_parser::{ComponentDeclaration, ComponentMemberKind, TypeContext};
 use crate::{
     ComponentId, ComponentMemberDeclaration, DeclarationId, HIRError, HirComponentDeclaration,
     Result, SymbolPointer,
-    builders::{HirQueueBuilder, PendantComponent, expression::ExpressionBuilder},
+    builders::{
+        HirQueueBuilder, PendantComponent,
+        expression::{ExpressionBuilder, ExpressionDescriptor},
+    },
     context::HirSymbol,
     id::{AnyDeclarationId, AnyLocalDeclarationId, OwnerId},
 };
@@ -170,9 +173,11 @@ impl ComponentBuilder {
                     let rhs = if let Some(rhs) = rhs {
                         Some(self.builder.build_expression(
                             queue,
-                            *rhs,
-                            component_type.props().get(prop_index).cloned(),
-                            &context,
+                            ExpressionDescriptor {
+                                target: *rhs,
+                                expected: component_type.props().get(prop_index).cloned(),
+                                context: &context,
+                            },
                         )?)
                     } else {
                         None

--- a/crates/hir/src/builders/expression/calls.rs
+++ b/crates/hir/src/builders/expression/calls.rs
@@ -9,18 +9,37 @@ use crate::{
     Result, builders::HirQueueBuilder,
 };
 
-use super::ExpressionBuilder;
+use super::{ExpressionBuilder, ExpressionDescriptor};
+
+///How the target of a function call is resolved.
+pub enum FunctionTarget<'a> {
+    ///The function has already been resolved to a declaration, along with any
+    ///explicit generic type arguments from the call site. Used for method
+    ///calls, where the target is resolved against its receiver type.
+    Resolved {
+        ///The function that is being called
+        target: DeclarationId<HirFunctionDeclaration>,
+        ///The explicit generic type arguments passed to this call, if any
+        type_arguments: &'a [Spanned<DedupPoolId<Type>>],
+    },
+    ///The function is referenced by its name in source (`foo<T>(a, b)`).
+    Free {
+        ///The type of the call, from which the function name and its generic
+        ///type arguments are derived
+        name: Spanned<DedupPoolId<Type>>,
+    },
+}
 
 ///A descriptor for a function call expression.
 pub struct FunctionCallDescriptor<'a> {
-    ///The function that is being called
-    pub target: DeclarationId<HirFunctionDeclaration>,
+    ///How the function being called is resolved
+    pub target: FunctionTarget<'a>,
     ///The arguments passed to this function call
-    pub received_args: &'a [Spanned<DedupPoolId<ASTExpression>>],
+    pub arguments: &'a [Spanned<DedupPoolId<ASTExpression>>],
     ///The arguments that are prepended to the call. This is useful method calls for example where the function call is such as 'a.call(5)', but the desugaring would transform it into 'call(a,5)'
-    pub prepend_arg: &'a [Spanned<PoolId<HirExpression>>],
-    ///The generic arguments passed to this function call
-    pub received_generics: &'a [Spanned<DedupPoolId<Type>>],
+    pub prepended_arguments: &'a [Spanned<PoolId<HirExpression>>],
+    ///The span of the call expression, used for error reporting
+    pub span: Span,
     ///The type context for this function call
     pub context: &'a TypeContext<'a>,
 }
@@ -28,36 +47,65 @@ pub struct FunctionCallDescriptor<'a> {
 impl FunctionCallDescriptor<'_> {
     ///Returns the total number of arguments passed to this function call, including prepended arguments.
     pub fn total_argument_length(&self) -> usize {
-        self.received_args.len() + self.prepend_arg.len()
+        self.arguments.len() + self.prepended_arguments.len()
     }
 }
 
 impl ExpressionBuilder {
-    pub(crate) fn build_call_for(
+    /// Builds a function call expression from a descriptor. This is the single
+    /// entry point for building function calls: it resolves the target when
+    /// given by name, checks the argument count, resolves the explicit generic
+    /// type arguments, infers any that are missing from the arguments, and
+    /// prepends arguments such as the receiver of a method call.
+    pub(super) fn build_function_call(
         &mut self,
         queue: &HirQueueBuilder<'_>,
-        descriptor: Spanned<FunctionCallDescriptor>,
+        descriptor: FunctionCallDescriptor<'_>,
     ) -> Result<HirExpression> {
-        let func_viewer = queue.hir.view(descriptor.target);
+        let total_arguments = descriptor.total_argument_length();
+        let FunctionCallDescriptor {
+            target,
+            arguments,
+            prepended_arguments,
+            span,
+            context,
+        } = descriptor;
+
+        let (target, type_arguments) = match target {
+            FunctionTarget::Resolved {
+                target,
+                type_arguments,
+            } => (target, type_arguments),
+            FunctionTarget::Free { name } => {
+                let identifier = queue.get_plain_type(name);
+                let target = self.lookup_function(
+                    queue,
+                    name.span.make_spanned(identifier.identifier),
+                    self.file(),
+                )?;
+                (target, &identifier.generic[..])
+            }
+        };
+
+        let func_viewer = queue.hir.view(target);
         let type_viewer = func_viewer.type_viewer();
 
         let expected_args = type_viewer.arguments();
 
-        if expected_args.len() != descriptor.total_argument_length() {
+        if expected_args.len() != total_arguments {
             let name = func_viewer.name();
             return Err(HIRError::invalid_funcall_arg_length(
                 name,
                 expected_args.len(),
-                descriptor.total_argument_length(),
-                descriptor.span,
+                total_arguments,
+                span,
             ));
         }
         let mut generics = queue
             .get_node(self.file())
-            .resolve_call_generics(descriptor.received_generics, descriptor.context)?;
+            .resolve_call_generics(type_arguments, context)?;
         let args = {
-            let transformed_arguments = descriptor
-                .received_args
+            let transformed_arguments = arguments
                 .iter()
                 .zip(expected_args)
                 .map(|(arg, ty)| {
@@ -68,8 +116,14 @@ impl ExpressionBuilder {
                         _ => None,
                     };
 
-                    let expr =
-                        self.build_expression(queue, *arg, expected_ty, descriptor.context)?;
+                    let expr = self.build_expression(
+                        queue,
+                        ExpressionDescriptor {
+                            target: *arg,
+                            expected: expected_ty,
+                            context,
+                        },
+                    )?;
                     if let HirType::GenericParam { index, .. } = queue.hir.view(*ty).raw()
                         && let None = expected_ty
                     {
@@ -79,8 +133,7 @@ impl ExpressionBuilder {
                     Ok(expr)
                 })
                 .collect::<Result<Vec<_>>>()?;
-            descriptor
-                .prepend_arg
+            prepended_arguments
                 .iter()
                 .cloned()
                 .chain(transformed_arguments.into_iter())
@@ -89,36 +142,11 @@ impl ExpressionBuilder {
         let ty = type_viewer.return_type();
         Ok(HirExpression {
             kind: HirExpressionKind::FunctionCall {
-                name: descriptor.target,
+                name: target,
                 args,
                 generics,
             },
             ty,
         })
-    }
-    /// Builds a function call expression for the function with the given `name`and `args`. This function might be changed to `build_call_for`
-    pub(super) fn build_function_call(
-        &mut self,
-        queue: &HirQueueBuilder<'_>,
-        name: Spanned<DedupPoolId<Type>>,
-        args: &[Spanned<DedupPoolId<ASTExpression>>],
-        context: &TypeContext,
-        span: Span,
-    ) -> Result<HirExpression> {
-        let identifier = queue.get_plain_type(name);
-        let func = self.lookup_function(
-            queue,
-            name.span.make_spanned(identifier.identifier),
-            self.file(),
-        )?;
-
-        let descriptor = FunctionCallDescriptor {
-            target: func,
-            received_args: args,
-            received_generics: &identifier.generic,
-            prepend_arg: &[],
-            context,
-        };
-        self.build_call_for(queue, span.make_spanned(descriptor))
     }
 }

--- a/crates/hir/src/builders/expression/calls.rs
+++ b/crates/hir/src/builders/expression/calls.rs
@@ -136,7 +136,7 @@ impl ExpressionBuilder {
             prepended_arguments
                 .iter()
                 .cloned()
-                .chain(transformed_arguments.into_iter())
+                .chain(transformed_arguments)
                 .collect()
         };
         let ty = type_viewer.return_type();

--- a/crates/hir/src/builders/expression/collections.rs
+++ b/crates/hir/src/builders/expression/collections.rs
@@ -7,7 +7,7 @@ use crate::{
     HIRError, HirExpression, HirExpressionKind, HirType, Result, builders::HirQueueBuilder,
 };
 
-use super::ExpressionBuilder;
+use super::{ExpressionBuilder, ExpressionDescriptor};
 
 impl ExpressionBuilder {
     pub(super) fn build_tuple_expression(
@@ -28,7 +28,14 @@ impl ExpressionBuilder {
             } else {
                 None
             };
-            let expr = self.build_expression(queue, *field, field_type, context)?;
+            let expr = self.build_expression(
+                queue,
+                ExpressionDescriptor {
+                    target: *field,
+                    expected: field_type,
+                    context,
+                },
+            )?;
             types.push(queue.hir[expr.data].ty);
             expressions.push(expr);
         }
@@ -47,7 +54,14 @@ impl ExpressionBuilder {
         index: usize,
         context: &TypeContext,
     ) -> Result<HirExpression> {
-        let expr = self.build_expression(queue, tuple, expected, context)?;
+        let expr = self.build_expression(
+            queue,
+            ExpressionDescriptor {
+                target: tuple,
+                expected,
+                context,
+            },
+        )?;
         let raw_expr = &queue.hir[expr.data];
         let parent_view = queue.hir.view(raw_expr.ty);
         let resolved = parent_view.dereference();
@@ -88,7 +102,14 @@ impl ExpressionBuilder {
         span: Span,
         context: &TypeContext,
     ) -> Result<HirExpression> {
-        let expr = self.build_expression(queue, expr, expected, context)?;
+        let expr = self.build_expression(
+            queue,
+            ExpressionDescriptor {
+                target: expr,
+                expected,
+                context,
+            },
+        )?;
         let after_index_type = {
             let expr_type = queue.hir[expr.data].ty;
             match &queue.hir.deref()[expr_type] {
@@ -100,7 +121,14 @@ impl ExpressionBuilder {
         };
         match range {
             RangeType::NoRange(index) => {
-                let index = self.build_expression(queue, *index, expected, context)?;
+                let index = self.build_expression(
+                    queue,
+                    ExpressionDescriptor {
+                        target: *index,
+                        expected,
+                        context,
+                    },
+                )?;
                 let viewer = queue.hir.view(index.data);
                 let ty_viewer = viewer.ty_viewer();
                 match ty_viewer.raw() {
@@ -141,14 +169,28 @@ impl ExpressionBuilder {
             };
         };
         let (inner_type, size) = expected.and_then(|e| queue.hir.view(e).is_array()).unzip();
-        let expr = self.build_expression(queue, *first, inner_type, context)?;
+        let expr = self.build_expression(
+            queue,
+            ExpressionDescriptor {
+                target: *first,
+                expected: inner_type,
+                context,
+            },
+        )?;
         let ty = queue.hir[expr.data].ty;
         if let Some(expected) = inner_type {
             self.unify_types(queue, ty, expected, span)?;
         }
         exprs.push(expr);
         for expr in &expressions[1..] {
-            let expr = self.build_expression(queue, *expr, Some(ty), context)?;
+            let expr = self.build_expression(
+                queue,
+                ExpressionDescriptor {
+                    target: *expr,
+                    expected: Some(ty),
+                    context,
+                },
+            )?;
             exprs.push(expr);
         }
         let final_length = size.unwrap_or(exprs.len());
@@ -187,14 +229,28 @@ impl ExpressionBuilder {
             };
         };
         let inner_type = expected.and_then(|e| queue.hir.view(e).is_vector());
-        let expr = self.build_expression(queue, *first, inner_type, context)?;
+        let expr = self.build_expression(
+            queue,
+            ExpressionDescriptor {
+                target: *first,
+                expected: inner_type,
+                context,
+            },
+        )?;
         let ty = queue.hir[expr.data].ty;
         if let Some(expected) = inner_type {
             self.unify_types(queue, ty, expected, span)?;
         }
         exprs.push(expr);
         for expr in &expressions[1..] {
-            let expr = self.build_expression(queue, *expr, Some(ty), context)?;
+            let expr = self.build_expression(
+                queue,
+                ExpressionDescriptor {
+                    target: *expr,
+                    expected: Some(ty),
+                    context,
+                },
+            )?;
             exprs.push(expr);
         }
         let final_type = queue.hir.create_type(HirType::Vector(ty));

--- a/crates/hir/src/builders/expression/components.rs
+++ b/crates/hir/src/builders/expression/components.rs
@@ -7,7 +7,7 @@ use crate::{
     context::HirSymbol,
 };
 
-use super::ExpressionBuilder;
+use super::{ExpressionBuilder, ExpressionDescriptor};
 
 impl ExpressionBuilder {
     pub(crate) fn build_component_expression(
@@ -54,8 +54,14 @@ impl ExpressionBuilder {
                         .ok_or_else(|| {
                             HIRError::property_unrecognized(ty, vec![*prop_name], span)
                         })?;
-                    let expr =
-                        self.build_expression(queue, *rhs, Some(comp_view.props()[pos]), context)?;
+                    let expr = self.build_expression(
+                        queue,
+                        ExpressionDescriptor {
+                            target: *rhs,
+                            expected: Some(comp_view.props()[pos]),
+                            context,
+                        },
+                    )?;
                     properties.push(PropertyExpression::new(pos, expr));
                 }
                 ComponentMemberValue::Child(child) => {

--- a/crates/hir/src/builders/expression/control_flow.rs
+++ b/crates/hir/src/builders/expression/control_flow.rs
@@ -5,21 +5,46 @@ use crate::{
     HirExpression, HirExpressionKind, HirStatement, HirType, Result, builders::HirQueueBuilder,
 };
 
-use super::ExpressionBuilder;
+use super::{ExpressionBuilder, ExpressionDescriptor};
+
+///A descriptor for an if expression.
+pub struct IfExpressionDescriptor<'a> {
+    ///The condition of the if expression
+    pub condition: Spanned<DedupPoolId<ASTExpression>>,
+    ///The statements of the then branch
+    pub body: &'a [Spanned<DedupPoolId<ASTStatement>>],
+    ///The statements of the else branch, if any
+    pub else_body: &'a [Spanned<DedupPoolId<ASTStatement>>],
+    ///The span of the if expression, used for error reporting
+    pub span: Span,
+    ///The expected type of the if expression, if known
+    pub expected: Option<DedupPoolId<HirType>>,
+    ///The type context used to resolve types
+    pub context: &'a TypeContext<'a>,
+}
 
 impl ExpressionBuilder {
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn build_if(
         &mut self,
         queue: &HirQueueBuilder,
-        condition: Spanned<DedupPoolId<ASTExpression>>,
-        body: &[Spanned<DedupPoolId<ASTStatement>>],
-        else_body: &[Spanned<DedupPoolId<ASTStatement>>],
-        span: Span,
-        expected: Option<DedupPoolId<HirType>>,
-        context: &TypeContext,
+        descriptor: IfExpressionDescriptor<'_>,
     ) -> Result<HirExpression> {
-        let condition = self.build_expression(queue, condition, expected, context)?;
+        let IfExpressionDescriptor {
+            condition,
+            body,
+            else_body,
+            span,
+            expected,
+            context,
+        } = descriptor;
+        let condition = self.build_expression(
+            queue,
+            ExpressionDescriptor {
+                target: condition,
+                expected,
+                context,
+            },
+        )?;
         let bool_ty = queue.hir.create_type(HirType::Bool);
         self.unify_types(queue, queue.hir[condition.data].ty, bool_ty, span)?;
 

--- a/crates/hir/src/builders/expression/field_access.rs
+++ b/crates/hir/src/builders/expression/field_access.rs
@@ -15,7 +15,6 @@ use crate::{
             literals::ReferenceExpressionDescriptor,
         },
     },
-    helpers::Visible,
 };
 
 use super::{ExpressionBuilder, ExpressionDescriptor};
@@ -97,7 +96,7 @@ impl ExpressionBuilder {
                     self.build_type_access(queue, file_owner, ty, *inner_parent, span, context)?;
                 self.build_field_access_impl(queue, parent, *inner_field, span, context)
             }
-            ASTExpression::Identifier(ident) => {
+            ASTExpression::Identifier(_) => {
                 unimplemented!("Constant values bound to types are not supported yet")
             }
             ASTExpression::FunctionCall { name, args } => {
@@ -139,178 +138,176 @@ impl ExpressionBuilder {
         span: Span,
         context: &TypeContext,
     ) -> Result<Spanned<PoolId<HirExpression>>> {
-        let expr = match queue.get_expr(field_ast.data) {
-            ASTExpression::FieldAccess {
-                parent: inner_parent,
-                field: inner_field,
-            } => {
-                let intermediate =
-                    self.build_field_access_impl(queue, parent, *inner_parent, span, context)?;
-                return self.build_field_access_impl(
-                    queue,
-                    intermediate,
-                    *inner_field,
-                    span,
-                    context,
-                );
-            }
-            ASTExpression::Identifier(field_name) => {
-                let parent_ty = queue.hir[parent.data].ty;
-                let parent_view = queue.hir.view(parent_ty);
-                let concrete_type = parent_view.concrete_type();
-                let dereferenced_type = parent_view.dereference();
-                match dereferenced_type.is_struct() {
-                    Some(view) => {
-                        let (fields, field_types) = (view.fields(), view.field_types());
-                        let position = fields
-                            .iter()
-                            .position(|f| f.data == *field_name)
-                            .ok_or_else(|| {
-                                HIRError::property_unrecognized(
-                                    dereferenced_type.data,
-                                    vec![*field_name],
-                                    span,
-                                )
-                            })?;
+        let expr =
+            match queue.get_expr(field_ast.data) {
+                ASTExpression::FieldAccess {
+                    parent: inner_parent,
+                    field: inner_field,
+                } => {
+                    let intermediate =
+                        self.build_field_access_impl(queue, parent, *inner_parent, span, context)?;
+                    return self.build_field_access_impl(
+                        queue,
+                        intermediate,
+                        *inner_field,
+                        span,
+                        context,
+                    );
+                }
+                ASTExpression::Identifier(field_name) => {
+                    let parent_ty = queue.hir[parent.data].ty;
+                    let parent_view = queue.hir.view(parent_ty);
+                    let concrete_type = parent_view.concrete_type();
+                    let dereferenced_type = parent_view.dereference();
+                    match dereferenced_type.is_struct() {
+                        Some(view) => {
+                            let (fields, field_types) = (view.fields(), view.field_types());
+                            let position = fields
+                                .iter()
+                                .position(|f| f.data == *field_name)
+                                .ok_or_else(|| {
+                                    HIRError::property_unrecognized(
+                                        dereferenced_type.data,
+                                        vec![*field_name],
+                                        span,
+                                    )
+                                })?;
 
-                        let field_ty = field_types[position];
-                        let field_ty = match queue.hir.view(parent_ty).raw() {
-                            HirType::Reference { generics, .. } => {
-                                queue.substitute_generics(generics, field_ty)
+                            let field_ty = field_types[position];
+                            let field_ty = match queue.hir.view(parent_ty).raw() {
+                                HirType::Reference { generics, .. } => {
+                                    queue.substitute_generics(generics, field_ty)
+                                }
+                                _ => field_ty,
+                            };
+                            HirExpression {
+                                ty: field_ty,
+                                kind: HirExpressionKind::FieldAccess {
+                                    expr: parent,
+                                    field_index: position,
+                                    field_name: Some(*field_name),
+                                },
                             }
-                            _ => field_ty,
-                        };
-                        HirExpression {
-                            ty: field_ty,
-                            kind: HirExpressionKind::FieldAccess {
-                                expr: parent,
-                                field_index: position,
-                                field_name: Some(*field_name),
-                            },
                         }
-                    }
-                    None if parent_view.dereference().is_ref()
-                        && let Some(view) = parent_view.concrete_type().is_struct() =>
-                    {
-                        let (fields, field_types) = (view.fields(), view.field_types());
-                        let position = fields
-                            .iter()
-                            .position(|f| f.data == *field_name)
-                            .ok_or_else(|| {
-                                HIRError::property_unrecognized(
-                                    concrete_type.data,
-                                    vec![*field_name],
-                                    span,
-                                )
-                            })?;
+                        None if parent_view.dereference().is_ref()
+                            && let Some(view) = parent_view.concrete_type().is_struct() =>
+                        {
+                            let (fields, field_types) = (view.fields(), view.field_types());
+                            let position = fields
+                                .iter()
+                                .position(|f| f.data == *field_name)
+                                .ok_or_else(|| {
+                                    HIRError::property_unrecognized(
+                                        concrete_type.data,
+                                        vec![*field_name],
+                                        span,
+                                    )
+                                })?;
 
-                        let field_ty = field_types[position];
-                        let field_ty = match queue.hir.view(parent_ty).raw() {
-                            HirType::Reference { generics, .. } => {
-                                queue.substitute_generics(generics, field_ty)
-                            }
-                            _ => field_ty,
-                        };
+                            let field_ty = field_types[position];
+                            let field_ty = match queue.hir.view(parent_ty).raw() {
+                                HirType::Reference { generics, .. } => {
+                                    queue.substitute_generics(generics, field_ty)
+                                }
+                                _ => field_ty,
+                            };
 
-                        let parent =
-                            parent
-                                .span
-                                .make_spanned(queue.hir.insert_expression(HirExpression {
+                            let parent = parent.span.make_spanned(queue.hir.insert_expression(
+                                HirExpression {
                                     ty: concrete_type.data,
                                     kind: HirExpressionKind::Deref(parent),
-                                }));
-                        HirExpression {
-                            ty: field_ty,
-                            kind: HirExpressionKind::FieldAccess {
-                                expr: parent,
-                                field_index: position,
-                                field_name: Some(*field_name),
-                            },
+                                },
+                            ));
+                            HirExpression {
+                                ty: field_ty,
+                                kind: HirExpressionKind::FieldAccess {
+                                    expr: parent,
+                                    field_index: position,
+                                    field_name: Some(*field_name),
+                                },
+                            }
+                        }
+                        None => {
+                            let ty = dereferenced_type.data;
+                            return Err(HIRError::not_a_struct(ty, span));
                         }
                     }
-                    None => {
-                        let ty = dereferenced_type.data;
-                        return Err(HIRError::not_a_struct(ty, span));
-                    }
                 }
-            }
-            ASTExpression::FunctionCall { name, args } => {
-                let name_sym = queue.type_name(name.data, &TypeContext::EMPTY);
-                let parent_type_view = queue.hir.view(queue.hir[parent.data].ty);
-                let parent_ty = parent_type_view.dereference();
-                match parent_ty.is_struct() {
-                    None => return Err(HIRError::not_a_struct(parent_ty.data, span)),
-                    Some(view) => {
-                        let func_id = if let Some(method) =
-                            view.method_named_as(name_sym, VisibilityModifier::Public)
-                        {
-                            Some(method)
-                        } else {
-                            queue
-                                .hir
-                                .methods
-                                .get(&parent_ty.data)
-                                .and_then(|methods| methods.get(&name_sym).map(|v| *v.value()))
-                        };
-
-                        let func_id = match func_id {
-                            Some(id) => id,
-                            None if let Some(id) = queue.resolve_method(
-                                self.file(),
-                                parent_ty.data,
-                                name_sym,
-                                span,
-                            )? =>
-                            {
-                                id
-                            }
-                            _ => {
-                                return Err(HIRError::missing_properties(vec![name_sym], span));
-                            }
-                        };
-
-                        let prepend_args = {
-                            let func_view = queue.hir.view(func_id);
-                            let first_arg = match func_view.get_argument_type(0) {
-                                Some(ty)
-                                    if let HirType::ImutableRef(_) | HirType::MutableRef(_) =
-                                        queue.hir.view(ty).raw() =>
+                ASTExpression::FunctionCall { name, args } => {
+                    let name_sym = queue.type_name(name.data, &TypeContext::EMPTY);
+                    let parent_type_view = queue.hir.view(queue.hir[parent.data].ty);
+                    let parent_ty = parent_type_view.dereference();
+                    match parent_ty.is_struct() {
+                        None => return Err(HIRError::not_a_struct(parent_ty.data, span)),
+                        Some(view) => {
+                            let func_id =
+                                if let Some(method) =
+                                    view.method_named_as(name_sym, VisibilityModifier::Public)
                                 {
-                                    let mutable =
-                                        matches!(queue.hir.view(ty).raw(), HirType::MutableRef(_));
-                                    let reference = self.build_reference_expression(
-                                        queue,
-                                        ReferenceExpressionDescriptor {
-                                            target: Either::Right(parent),
-                                            mutable: mutable,
-                                            context,
-                                        },
-                                    )?;
-                                    reference
+                                    Some(method)
+                                } else {
+                                    queue.hir.methods.get(&parent_ty.data).and_then(|methods| {
+                                        methods.get(&name_sym).map(|v| *v.value())
+                                    })
+                                };
+
+                            let func_id = match func_id {
+                                Some(id) => id,
+                                None if let Some(id) = queue.resolve_method(
+                                    self.file(),
+                                    parent_ty.data,
+                                    name_sym,
+                                    span,
+                                )? =>
+                                {
+                                    id
                                 }
-                                _ => parent,
+                                _ => {
+                                    return Err(HIRError::missing_properties(vec![name_sym], span));
+                                }
                             };
-                            [first_arg]
-                        };
-                        let call = self.build_function_call(
-                            queue,
-                            FunctionCallDescriptor {
-                                target: FunctionTarget::Resolved {
-                                    target: func_id,
-                                    type_arguments: &queue.get_plain_type(*name).generic,
+
+                            let prepend_args = {
+                                let func_view = queue.hir.view(func_id);
+                                let first_arg = match func_view.get_argument_type(0) {
+                                    Some(ty)
+                                        if let HirType::ImutableRef(_) | HirType::MutableRef(_) =
+                                            queue.hir.view(ty).raw() =>
+                                    {
+                                        self.build_reference_expression(
+                                            queue,
+                                            ReferenceExpressionDescriptor {
+                                                target: Either::Right(parent),
+                                                mutable: matches!(
+                                                    queue.hir.view(ty).raw(),
+                                                    HirType::MutableRef(_)
+                                                ),
+                                                context,
+                                            },
+                                        )?
+                                    }
+                                    _ => parent,
+                                };
+                                [first_arg]
+                            };
+                            self.build_function_call(
+                                queue,
+                                FunctionCallDescriptor {
+                                    target: FunctionTarget::Resolved {
+                                        target: func_id,
+                                        type_arguments: &queue.get_plain_type(*name).generic,
+                                    },
+                                    arguments: args,
+                                    prepended_arguments: &prepend_args,
+                                    span,
+                                    context,
                                 },
-                                arguments: args,
-                                prepended_arguments: &prepend_args,
-                                span,
-                                context,
-                            },
-                        )?;
-                        call
+                            )?
+                        }
                     }
                 }
-            }
-            _ => return Err(HIRError::invalid_field_access(span)),
-        };
+                _ => return Err(HIRError::invalid_field_access(span)),
+            };
         Ok(span.make_spanned(queue.hir.insert_expression(expr)))
     }
 }

--- a/crates/hir/src/builders/expression/field_access.rs
+++ b/crates/hir/src/builders/expression/field_access.rs
@@ -10,34 +10,71 @@ use crate::{
     HIRError, HirExpression, HirExpressionKind, HirType, Result,
     builders::{
         HirQueueBuilder,
-        expression::{calls::FunctionCallDescriptor, literals::ReferenceExpressionDescriptor},
+        expression::{
+            calls::{FunctionCallDescriptor, FunctionTarget},
+            literals::ReferenceExpressionDescriptor,
+        },
     },
     helpers::Visible,
 };
 
-use super::ExpressionBuilder;
+use super::{ExpressionBuilder, ExpressionDescriptor};
+
+///A descriptor for a field (or type member) access expression.
+pub struct FieldAccessDescriptor<'a> {
+    ///The parent we are accessing a member from. It can either be a raw AST
+    ///expression that still needs to be built, or an already-built HIR
+    ///expression (used when chaining accesses).
+    pub parent: Either<Spanned<DedupPoolId<ASTExpression>>, Spanned<PoolId<HirExpression>>>,
+    ///The field (or method) being accessed
+    pub field: Spanned<DedupPoolId<ASTExpression>>,
+    ///The span of the access expression, used for error reporting
+    pub span: Span,
+    ///The expected type of the access, if known
+    pub expected: Option<DedupPoolId<HirType>>,
+    ///The type context used to resolve types
+    pub context: &'a TypeContext<'a>,
+}
 
 impl ExpressionBuilder {
-    pub(super) fn build_access(
+    ///Builds a member access on a parent expression. When the parent names a
+    ///type, this resolves a static member access (such as a static method);
+    ///otherwise it builds a value field access.
+    pub(super) fn build_field_access(
         &mut self,
         queue: &HirQueueBuilder,
-        parent: Spanned<DedupPoolId<ASTExpression>>,
-        field_ast: Spanned<DedupPoolId<ASTExpression>>,
-        expected: Option<DedupPoolId<HirType>>,
-        span: Span,
-        context: &TypeContext,
+        descriptor: FieldAccessDescriptor<'_>,
     ) -> Result<Spanned<PoolId<HirExpression>>> {
-        match queue.get_expr(parent.data) {
-            ASTExpression::Identifier(ident)
-                if let Ok((file, ty)) = queue
-                    .get_node(self.file())
-                    .find_type_named_as(parent.span.make_spanned(*ident), context) =>
-            {
-                self.build_type_access(queue, file, ty, field_ast, span, context)
-            }
-            _ => {
-                let parent = self.build_expression(queue, parent, expected, context)?;
-                self.build_field_access(queue, parent, field_ast, span, context)
+        let FieldAccessDescriptor {
+            parent,
+            field,
+            span,
+            expected,
+            context,
+        } = descriptor;
+        match parent {
+            Either::Left(parent) => match queue.get_expr(parent.data) {
+                ASTExpression::Identifier(ident)
+                    if let Ok((file, ty)) = queue
+                        .get_node(self.file())
+                        .find_type_named_as(parent.span.make_spanned(*ident), context) =>
+                {
+                    self.build_type_access(queue, file, ty, field, span, context)
+                }
+                _ => {
+                    let parent = self.build_expression(
+                        queue,
+                        ExpressionDescriptor {
+                            target: parent,
+                            expected,
+                            context,
+                        },
+                    )?;
+                    self.build_field_access_impl(queue, parent, field, span, context)
+                }
+            },
+            Either::Right(parent) => {
+                self.build_field_access_impl(queue, parent, field, span, context)
             }
         }
     }
@@ -58,7 +95,7 @@ impl ExpressionBuilder {
             } => {
                 let parent =
                     self.build_type_access(queue, file_owner, ty, *inner_parent, span, context)?;
-                self.build_field_access(queue, parent, *inner_field, span, context)
+                self.build_field_access_impl(queue, parent, *inner_field, span, context)
             }
             ASTExpression::Identifier(ident) => {
                 unimplemented!("Constant values bound to types are not supported yet")
@@ -70,15 +107,18 @@ impl ExpressionBuilder {
                         let plain = queue.get_plain_type(*name);
                         &plain.generic
                     };
-                    let call = self.build_call_for(
+                    let call = self.build_function_call(
                         queue,
-                        child.span.make_spanned(FunctionCallDescriptor {
-                            target: method,
-                            received_args: args,
-                            prepend_arg: &[],
-                            received_generics: generics,
+                        FunctionCallDescriptor {
+                            target: FunctionTarget::Resolved {
+                                target: method,
+                                type_arguments: generics,
+                            },
+                            arguments: args,
+                            prepended_arguments: &[],
+                            span,
                             context,
-                        }),
+                        },
                     )?;
 
                     Ok(span.make_spanned(queue.hir.insert_expression(call)))
@@ -90,7 +130,8 @@ impl ExpressionBuilder {
         }
     }
 
-    pub(super) fn build_field_access(
+    ///Builds a member access against an already-built parent expression.
+    fn build_field_access_impl(
         &mut self,
         queue: &HirQueueBuilder,
         parent: Spanned<PoolId<HirExpression>>,
@@ -104,8 +145,14 @@ impl ExpressionBuilder {
                 field: inner_field,
             } => {
                 let intermediate =
-                    self.build_field_access(queue, parent, *inner_parent, span, context)?;
-                return self.build_field_access(queue, intermediate, *inner_field, span, context);
+                    self.build_field_access_impl(queue, parent, *inner_parent, span, context)?;
+                return self.build_field_access_impl(
+                    queue,
+                    intermediate,
+                    *inner_field,
+                    span,
+                    context,
+                );
             }
             ASTExpression::Identifier(field_name) => {
                 let parent_ty = queue.hir[parent.data].ty;
@@ -245,15 +292,18 @@ impl ExpressionBuilder {
                             };
                             [first_arg]
                         };
-                        let call = self.build_call_for(
+                        let call = self.build_function_call(
                             queue,
-                            span.make_spanned(FunctionCallDescriptor {
-                                target: func_id,
-                                received_args: args,
-                                prepend_arg: &prepend_args,
-                                received_generics: &queue.get_plain_type(*name).generic,
+                            FunctionCallDescriptor {
+                                target: FunctionTarget::Resolved {
+                                    target: func_id,
+                                    type_arguments: &queue.get_plain_type(*name).generic,
+                                },
+                                arguments: args,
+                                prepended_arguments: &prepend_args,
+                                span,
                                 context,
-                            }),
+                            },
                         )?;
                         call
                     }

--- a/crates/hir/src/builders/expression/literals.rs
+++ b/crates/hir/src/builders/expression/literals.rs
@@ -12,7 +12,7 @@ use crate::{
     builders::HirQueueBuilder, error::NotMutableReason,
 };
 
-use super::ExpressionBuilder;
+use super::{ExpressionBuilder, ExpressionDescriptor};
 
 pub struct ReferenceExpressionDescriptor<'a> {
     ///The target we will build the reference for.
@@ -40,9 +40,11 @@ impl ExpressionBuilder {
     ) -> Result<HirExpression> {
         let build_expr = self.build_expression(
             queue,
-            descriptor.target,
-            descriptor.expected,
-            descriptor.context,
+            ExpressionDescriptor {
+                target: descriptor.target,
+                expected: descriptor.expected,
+                context: descriptor.context,
+            },
         )?;
         let expr_ty = queue.hir.view(build_expr.data).ty();
         let expr_ty = match queue.hir.view(expr_ty).raw() {
@@ -63,9 +65,14 @@ impl ExpressionBuilder {
         descriptor: ReferenceExpressionDescriptor,
     ) -> Result<Spanned<PoolId<HirExpression>>> {
         let hir_expression = match descriptor.target {
-            Either::Left(ast_expression) => {
-                self.build_expression(queue, ast_expression, None, descriptor.context)?
-            }
+            Either::Left(ast_expression) => self.build_expression(
+                queue,
+                ExpressionDescriptor {
+                    target: ast_expression,
+                    expected: None,
+                    context: descriptor.context,
+                },
+            )?,
             Either::Right(hir_expression) => hir_expression,
         };
         let expression_viewer = queue.hir.view(hir_expression.data);

--- a/crates/hir/src/builders/expression/mod.rs
+++ b/crates/hir/src/builders/expression/mod.rs
@@ -16,7 +16,11 @@ use crate::{
     VariableId,
     builders::{
         HirQueueBuilder,
-        expression::literals::{DereferenceExpressionDescriptor, ReferenceExpressionDescriptor},
+        expression::{
+            calls::{FunctionCallDescriptor, FunctionTarget},
+            field_access::FieldAccessDescriptor,
+            literals::{DereferenceExpressionDescriptor, ReferenceExpressionDescriptor},
+        },
     },
     context::ScopeContext,
     id::OwnerId,
@@ -32,6 +36,18 @@ mod names;
 mod objects;
 mod statements;
 mod typing;
+
+use self::{control_flow::IfExpressionDescriptor, objects::ObjectDescriptor};
+
+///A descriptor for building an expression.
+pub struct ExpressionDescriptor<'a> {
+    ///The AST expression to build
+    pub target: Spanned<DedupPoolId<ASTExpression>>,
+    ///The expected type of the expression, if known
+    pub expected: Option<DedupPoolId<HirType>>,
+    ///The type context used to resolve types
+    pub context: &'a TypeContext<'a>,
+}
 
 /// Result of building a body with the ExpressionBuilder.
 pub(crate) struct ExpressionBuildResult {
@@ -175,11 +191,14 @@ impl ExpressionBuilder {
     pub(crate) fn build_expression(
         &mut self,
         queue: &HirQueueBuilder<'_>,
-        expression: Spanned<DedupPoolId<ASTExpression>>,
-        expected: Option<DedupPoolId<HirType>>,
-        context: &TypeContext,
+        descriptor: ExpressionDescriptor<'_>,
     ) -> Result<Spanned<PoolId<HirExpression>>> {
-        let expr = queue.get_expr(expression.data);
+        let ExpressionDescriptor {
+            target,
+            expected,
+            context,
+        } = descriptor;
+        let expr = queue.get_expr(target.data);
         let expr = match expr {
             ASTExpression::Deref(expr) => self.build_deref(
                 queue,
@@ -199,14 +218,14 @@ impl ExpressionBuilder {
                     },
                 );
             }
-            ASTExpression::Null => self.build_null(queue, expression.span, expected)?,
+            ASTExpression::Null => self.build_null(queue, target.span, expected)?,
             ASTExpression::IndexExpression(expr, range) => {
-                self.build_index(queue, *expr, range, expected, expression.span, context)?
+                self.build_index(queue, *expr, range, expected, target.span, context)?
             }
             ASTExpression::False => self.build_bool(queue, false),
             ASTExpression::True => self.build_bool(queue, true),
             ASTExpression::Identifier(name) => {
-                self.build_identifier(queue, *name, expression.span)?
+                self.build_identifier(queue, *name, target.span)?
             }
             ASTExpression::IntLiteral(i) => self.build_int_literal(queue, *i),
             ASTExpression::FloatLiteral(f) => self.build_float_literal(queue, f.into_inner()),
@@ -216,29 +235,45 @@ impl ExpressionBuilder {
             }
 
             ASTExpression::FieldAccess { parent, field } => {
-                return self.build_access(
+                return self.build_field_access(
                     queue,
-                    *parent,
-                    *field,
-                    expected,
-                    expression.span,
-                    context,
+                    FieldAccessDescriptor {
+                        parent: Either::Left(*parent),
+                        field: *field,
+                        span: target.span,
+                        expected,
+                        context,
+                    },
                 );
             }
             ASTExpression::TupleAccess { tuple, index } => self.build_tuple_access(
                 queue,
                 *tuple,
                 expected,
-                expression.span,
+                target.span,
                 *index as usize,
                 context,
             )?,
             ASTExpression::Binary { lhs, op, rhs } => {
-                let lhs = self.build_expression(queue, *lhs, expected, context)?;
-                let rhs = self.build_expression(queue, *rhs, expected, context)?;
+                let lhs = self.build_expression(
+                    queue,
+                    ExpressionDescriptor {
+                        target: *lhs,
+                        expected,
+                        context,
+                    },
+                )?;
+                let rhs = self.build_expression(
+                    queue,
+                    ExpressionDescriptor {
+                        target: *rhs,
+                        expected,
+                        context,
+                    },
+                )?;
                 let lhs_ty = queue.hir.view(lhs.data).ty();
                 let rhs_ty = queue.hir.view(rhs.data).ty();
-                let ty = self.unify_types(queue, lhs_ty, rhs_ty, expression.span)?;
+                let ty = self.unify_types(queue, lhs_ty, rhs_ty, target.span)?;
                 let ty = if op.is_logical() {
                     queue.hir.create_type(HirType::Bool)
                 } else {
@@ -246,41 +281,57 @@ impl ExpressionBuilder {
                 };
                 queue.hir.create_binary_expression(lhs, rhs, *op, ty)
             }
-            ASTExpression::FunctionCall { name, args } => {
-                self.build_function_call(queue, *name, args, context, expression.span)?
-            }
+            ASTExpression::FunctionCall { name, args } => self.build_function_call(
+                queue,
+                FunctionCallDescriptor {
+                    target: FunctionTarget::Free { name: *name },
+                    arguments: args,
+                    prepended_arguments: &[],
+                    span: target.span,
+                    context,
+                },
+            )?,
             ASTExpression::If {
                 condition,
                 body,
                 else_body,
             } => self.build_if(
                 queue,
-                *condition,
-                body,
-                else_body,
-                expression.span,
-                expected,
-                context,
+                IfExpressionDescriptor {
+                    condition: *condition,
+                    body,
+                    else_body,
+                    span: target.span,
+                    expected,
+                    context,
+                },
             )?,
             ASTExpression::Component(component) => {
                 let child =
-                    self.build_component_expression(queue, component, expression.span, context)?;
+                    self.build_component_expression(queue, component, target.span, context)?;
                 HirExpression {
                     ty: queue.hir[child.data].name,
                     kind: HirExpressionKind::Component(child),
                 }
             }
-            ASTExpression::ObjectExpression { name, fields } => {
-                self.build_object(queue, *name, fields, expression.span, expected, context)?
-            }
+            ASTExpression::ObjectExpression { name, fields } => self.build_object(
+                queue,
+                ObjectDescriptor {
+                    name: *name,
+                    fields,
+                    span: target.span,
+                    expected,
+                    context,
+                },
+            )?,
             ASTExpression::Array(expressions) => {
-                self.build_array(queue, expressions, expression.span, expected, context)?
+                self.build_array(queue, expressions, target.span, expected, context)?
             }
             ASTExpression::Vector(expressions) => {
-                self.build_vector(queue, expressions, expression.span, expected, context)?
+                self.build_vector(queue, expressions, target.span, expected, context)?
             }
         };
         let exprid = queue.hir.insert_expression(expr);
-        Ok(expression.span.make_spanned(exprid))
+        Ok(target.span.make_spanned(exprid))
     }
 }

--- a/crates/hir/src/builders/expression/mod.rs
+++ b/crates/hir/src/builders/expression/mod.rs
@@ -157,7 +157,7 @@ impl ExpressionBuilder {
                     .variables
                     .variables
                     .get(&ident)
-                    .map_or(false, |info| info.mutable)
+                    .is_some_and(|info| info.mutable)
                 {
                     Ok(())
                 } else {

--- a/crates/hir/src/builders/expression/mod.rs
+++ b/crates/hir/src/builders/expression/mod.rs
@@ -224,9 +224,7 @@ impl ExpressionBuilder {
             }
             ASTExpression::False => self.build_bool(queue, false),
             ASTExpression::True => self.build_bool(queue, true),
-            ASTExpression::Identifier(name) => {
-                self.build_identifier(queue, *name, target.span)?
-            }
+            ASTExpression::Identifier(name) => self.build_identifier(queue, *name, target.span)?,
             ASTExpression::IntLiteral(i) => self.build_int_literal(queue, *i),
             ASTExpression::FloatLiteral(f) => self.build_float_literal(queue, f.into_inner()),
             ASTExpression::StringLiteral(s) => self.build_str_literal(queue, *s),

--- a/crates/hir/src/builders/expression/objects.rs
+++ b/crates/hir/src/builders/expression/objects.rs
@@ -7,19 +7,36 @@ use crate::{
     HIRError, HirExpression, HirExpressionKind, HirType, Result, builders::HirQueueBuilder,
 };
 
-use super::ExpressionBuilder;
+use super::{ExpressionBuilder, ExpressionDescriptor};
+
+///A descriptor for an object literal expression.
+pub struct ObjectDescriptor<'a> {
+    ///The type of the object being constructed
+    pub name: Spanned<DedupPoolId<Type>>,
+    ///The named fields of the object literal
+    pub fields: &'a [Spanned<NamedExpr>],
+    ///The span of the object literal, used for error reporting
+    pub span: Span,
+    ///The expected type of the object, if known
+    pub expected: Option<DedupPoolId<HirType>>,
+    ///The type context used to resolve types
+    pub context: &'a TypeContext<'a>,
+}
 
 impl ExpressionBuilder {
 
     pub(super) fn build_object(
         &mut self,
         queue: &HirQueueBuilder,
-        name: Spanned<DedupPoolId<Type>>,
-        fields: &[Spanned<NamedExpr>],
-        span: Span,
-        expected: Option<DedupPoolId<HirType>>,
-        context: &TypeContext,
+        descriptor: ObjectDescriptor<'_>,
     ) -> Result<HirExpression> {
+        let ObjectDescriptor {
+            name,
+            fields,
+            span,
+            expected,
+            context,
+        } = descriptor;
 
         let ty = if let Some(self_type) = &self.self_type {
             queue.find_self_type(name.data, *self_type)
@@ -98,7 +115,14 @@ impl ExpressionBuilder {
                             .expect("Field name should've been added into type names");
 
                         let field_ty = queue.substitute_generics(generics, obj.field_types()[*idx]);
-                        self.build_expression(queue, field.data.expr, Some(field_ty), context)?
+                        self.build_expression(
+                            queue,
+                            ExpressionDescriptor {
+                                target: field.data.expr,
+                                expected: Some(field_ty),
+                                context,
+                            },
+                        )?
                     }),
                     None => missing.push(obj.fields()[i].data),
                 }

--- a/crates/hir/src/builders/expression/objects.rs
+++ b/crates/hir/src/builders/expression/objects.rs
@@ -24,7 +24,6 @@ pub struct ObjectDescriptor<'a> {
 }
 
 impl ExpressionBuilder {
-
     pub(super) fn build_object(
         &mut self,
         queue: &HirQueueBuilder,
@@ -40,7 +39,7 @@ impl ExpressionBuilder {
 
         let ty = if let Some(self_type) = &self.self_type {
             queue.find_self_type(name.data, *self_type)
-        }else {
+        } else {
             queue.get_node(self.file()).find_type(name, context)?.1
         };
         let ty_view = queue.hir.view(ty);

--- a/crates/hir/src/builders/expression/statements.rs
+++ b/crates/hir/src/builders/expression/statements.rs
@@ -6,7 +6,7 @@ use slynx_parser::{ASTStatement, TypeContext};
 
 use crate::{HirStatement, HirType, Result, builders::HirQueueBuilder};
 
-use super::ExpressionBuilder;
+use super::{ExpressionBuilder, ExpressionDescriptor};
 
 impl ExpressionBuilder {
     pub(crate) fn build_statement(
@@ -32,7 +32,14 @@ impl ExpressionBuilder {
         let stmt = queue.get_statement(statement.data);
         let data = match stmt {
             ASTStatement::Expression(e) => {
-                let expr = self.build_expression(queue, *e, None, context)?;
+                let expr = self.build_expression(
+                    queue,
+                    ExpressionDescriptor {
+                        target: *e,
+                        expected: None,
+                        context,
+                    },
+                )?;
 
                 HirStatement::Expression { expr }
             }
@@ -42,7 +49,14 @@ impl ExpressionBuilder {
                 } else {
                     None
                 };
-                let expr = self.build_expression(queue, *rhs, var_type, context)?;
+                let expr = self.build_expression(
+                    queue,
+                    ExpressionDescriptor {
+                        target: *rhs,
+                        expected: var_type,
+                        context,
+                    },
+                )?;
                 let exprty = queue.hir.view(expr.data).ty();
                 let expected_type = if let Some(expected_ty) = ty {
                     queue
@@ -66,9 +80,23 @@ impl ExpressionBuilder {
                 }
             }
             ASTStatement::Assign { lhs, rhs } => {
-                let lhs = self.build_expression(queue, *lhs, None, context)?;
+                let lhs = self.build_expression(
+                    queue,
+                    ExpressionDescriptor {
+                        target: *lhs,
+                        expected: None,
+                        context,
+                    },
+                )?;
                 self.is_expression_able_to_write(queue, lhs)?;
-                let rhs = self.build_expression(queue, *rhs, None, context)?;
+                let rhs = self.build_expression(
+                    queue,
+                    ExpressionDescriptor {
+                        target: *rhs,
+                        expected: None,
+                        context,
+                    },
+                )?;
                 self.unify_types(
                     queue,
                     queue.hir.view(rhs.data).ty(),
@@ -80,9 +108,11 @@ impl ExpressionBuilder {
             ASTStatement::While { condition, body } => {
                 let condition = self.build_expression(
                     queue,
-                    *condition,
-                    Some(queue.hir.create_type(HirType::Bool)),
-                    context,
+                    ExpressionDescriptor {
+                        target: *condition,
+                        expected: Some(queue.hir.create_type(HirType::Bool)),
+                        context,
+                    },
                 )?;
                 let body = body
                     .iter()
@@ -93,7 +123,16 @@ impl ExpressionBuilder {
             }
             ASTStatement::Return { value } => {
                 let expr = value
-                    .map(|v| self.build_expression(queue, v, None, context))
+                    .map(|v| {
+                        self.build_expression(
+                            queue,
+                            ExpressionDescriptor {
+                                target: v,
+                                expected: None,
+                                context,
+                            },
+                        )
+                    })
                     .transpose()?;
                 HirStatement::Return { expr }
             }

--- a/crates/hir/src/builders/function.rs
+++ b/crates/hir/src/builders/function.rs
@@ -65,7 +65,7 @@ impl<'a> HirQueueBuilder<'a> {
             func_id: id,
             body: &f.body,
             argument_names: names,
-            self_type: None
+            self_type: None,
         });
         Ok(id)
     }
@@ -85,7 +85,7 @@ impl<'a> HirQueueBuilder<'a> {
         } else if let Some(func) = self.hir.get_file(requester).find_function_with_name(name) {
             Ok(func)
         } else if let Some((id, index)) = self.find_function_declaration(name, requester) {
-                let func = &self.modules.get_entry(id).func()[index];
+            let func = &self.modules.get_entry(id).func()[index];
             self.enqueue_function(func, id)
         } else {
             Err(HIRError::name_unrecognized(name, span))
@@ -94,7 +94,10 @@ impl<'a> HirQueueBuilder<'a> {
 }
 
 impl HirFunctionBuilder {
-    pub fn new(target: DeclarationId<HirFunctionDeclaration>, self_type: Option<DedupPoolId<HirType>>) -> Self {
+    pub fn new(
+        target: DeclarationId<HirFunctionDeclaration>,
+        self_type: Option<DedupPoolId<HirType>>,
+    ) -> Self {
         Self {
             target,
             builder: ExpressionBuilder::new(OwnerId::Function(target), self_type),

--- a/crates/hir/src/builders/mod.rs
+++ b/crates/hir/src/builders/mod.rs
@@ -5,7 +5,7 @@ mod function;
 mod structs;
 pub(crate) mod styles;
 mod work_channel;
-use std::{cell::RefCell, collections::VecDeque, ops::Deref};
+use std::{cell::RefCell, ops::Deref};
 
 use common::{
     Spanned,
@@ -414,9 +414,9 @@ impl<'a> HirQueueBuilder<'a> {
                     if let Ok(PendantFunction { func_id, body, argument_names, context, self_type }) = body {
                         let mut builder = HirFunctionBuilder::new(func_id, self_type);
                         for (idx, name) in argument_names.into_iter().enumerate() {
-                            builder.create_argument(&self, name, idx as u8);
+                            builder.create_argument(self, name, idx as u8);
                         }
-                        let ExpressionBuildResult { statements, args } = builder.build_body(&self, body, &context)?;
+                        let ExpressionBuildResult { statements, args } = builder.build_body(self, body, &context)?;
                         self.resolved_bodies.insert(func_id, (statements, args));
 
                         if self.bodies.receiver().is_empty() {
@@ -428,7 +428,7 @@ impl<'a> HirQueueBuilder<'a> {
                 }
                 recv(self.components.receiver()) -> component => {
                     if let Ok(PendantComponent { owner, component }) = component {
-                        let decls = self.component_body(owner, &self, component)?;
+                        let decls = self.component_body(owner, self, component)?;
                         self.resolved_components.insert(owner, decls);
                     }
                 }

--- a/crates/hir/src/builders/structs.rs
+++ b/crates/hir/src/builders/structs.rs
@@ -1,6 +1,6 @@
 use common::{Span, Spanned, pool::DedupPoolId};
 use module_loader::{ASTType, ASTTypeKind, FileId};
-use slynx_parser::{ASTExpression, ObjectMethod, Type, TypeContext};
+use slynx_parser::{ASTExpression, Type, TypeContext};
 
 use crate::{
     DeclarationId, HIRError, HirFunctionDeclaration, HirQueueBuilder, HirType, PendantFunction,

--- a/crates/hir/src/helpers/views/types.rs
+++ b/crates/hir/src/helpers/views/types.rs
@@ -164,14 +164,12 @@ impl HirViewer<'_, DedupPoolId<HirType>> {
     ///
     pub fn concrete_type(&self) -> HirViewer<'_, DedupPoolId<HirType>> {
         let mut data = self.data;
-        loop {
-            match self.hir.deref()[data] {
-                HirType::Nullable(rf)
-                | HirType::ImutableRef(rf)
-                | HirType::MutableRef(rf)
-                | HirType::Reference { rf, .. } => data = rf,
-                _ => break,
-            }
+        while let HirType::Nullable(rf)
+        | HirType::ImutableRef(rf)
+        | HirType::MutableRef(rf)
+        | HirType::Reference { rf, .. } = self.hir.deref()[data]
+        {
+            data = rf
         }
         self.new_with(data)
     }

--- a/crates/hir/src/ownership/analysis.rs
+++ b/crates/hir/src/ownership/analysis.rs
@@ -8,7 +8,7 @@ use common::{Span, Spanned, pool::PoolId};
 
 use crate::{
     DeclarationId, HirExpression, HirExpressionKind, HirFunctionDeclaration, HirStatement,
-    HirStaticDeclaration, SlynxHir, VariableId, model::HirPlace,
+    SlynxHir, VariableId, model::HirPlace,
 };
 
 use super::{
@@ -16,7 +16,7 @@ use super::{
 };
 
 /// The result of ownership analysis on the entire HIR.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct OwnershipAnalysis {
     /// For each function, its ownership state at the end of analysis.
     pub function_states: HashMap<DeclarationId<HirFunctionDeclaration>, FunctionOwnershipState>,
@@ -302,41 +302,39 @@ impl OwnershipAnalysis {
             BorrowKind::Immutable
         };
 
-        if let Some(place_id) = self.build_place_from_expr(hir, inner.data) {
-            match &hir.places[place_id] {
-                HirPlace::Variable(id) => {
-                    if !state.can_borrow_variable(*id, kind) {
-                        if state.is_variable_moved(*id) {
-                            self.errors.push(OwnershipError {
-                                kind: OwnershipErrorKind::UseAfterMove { variable: *id },
-                                span,
-                            });
-                            return;
-                        }
-                        let existing_kind = if state
-                            .variable_states
-                            .get(id)
-                            .map(|s| s.borrowed_mut > 0)
-                            .unwrap_or(false)
-                        {
-                            BorrowKind::Mutable
-                        } else {
-                            BorrowKind::Immutable
-                        };
-                        self.errors.push(OwnershipError {
-                            kind: OwnershipErrorKind::ConflictingBorrow {
-                                variable: *id,
-                                existing_borrow: existing_kind,
-                                new_borrow: kind,
-                            },
-                            span,
-                        });
-                        return;
-                    }
-
-                    state.borrow_variable(*id, kind);
+        if let Some(place_id) = self.build_place_from_expr(hir, inner.data)
+            && let HirPlace::Variable(id) = &hir.places[place_id]
+        {
+            match () {
+                _ if state.can_borrow_variable(*id, kind) => state.borrow_variable(*id, kind),
+                _ if state.is_variable_moved(*id) => {
+                    self.errors.push(OwnershipError {
+                        kind: OwnershipErrorKind::UseAfterMove { variable: *id },
+                        span,
+                    });
+                    return;
                 }
-                _ => {}
+                _ => {
+                    let existing_kind = if state
+                        .variable_states
+                        .get(id)
+                        .map(|s| s.borrowed_mut > 0)
+                        .unwrap_or(false)
+                    {
+                        BorrowKind::Mutable
+                    } else {
+                        BorrowKind::Immutable
+                    };
+                    self.errors.push(OwnershipError {
+                        kind: OwnershipErrorKind::ConflictingBorrow {
+                            variable: *id,
+                            existing_borrow: existing_kind,
+                            new_borrow: kind,
+                        },
+                        span,
+                    });
+                    return;
+                }
             }
         }
 

--- a/crates/hir/src/ownership/state.rs
+++ b/crates/hir/src/ownership/state.rs
@@ -21,7 +21,7 @@ impl std::fmt::Display for BorrowKind {
 }
 
 /// The state of a single place in the ownership system.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PlaceState {
     /// Number of active mutable borrows.
     pub borrowed_mut: u8,
@@ -69,7 +69,7 @@ impl PlaceState {
 ///
 /// Tracks the state of all places used in a function, including
 /// variables, temporaries, and projections.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct FunctionOwnershipState {
     /// State for each variable (by VariableId).
     pub variable_states: HashMap<VariableId, PlaceState>,
@@ -86,16 +86,11 @@ impl FunctionOwnershipState {
 
     /// Get the state for a variable, creating a default state if not present.
     pub fn get_variable_state(&mut self, id: VariableId) -> &mut PlaceState {
-        self.variable_states
-            .entry(id)
-            .or_insert_with(PlaceState::new)
+        self.variable_states.entry(id).or_default()
     }
 
     pub fn mark_static_moved(&mut self, id: DeclarationId<HirStaticDeclaration>) {
-        self.static_states
-            .entry(id)
-            .or_insert_with(PlaceState::new)
-            .moved = true;
+        self.static_states.entry(id).or_default().moved = true;
     }
     pub fn is_static_moved(&self, id: DeclarationId<HirStaticDeclaration>) -> bool {
         self.static_states


### PR DESCRIPTION
## Summary

This PR simply refactors the HIR expression builder to use descriptors. The methods that use an descriptor are intended to be a defacto method

## Scope

- Function arguments on a lot of methods were replaced by using a descriptor instead
- No code logic was change

## Validation

List the commands, tests, or manual checks you ran.

```bash
make test
```

## Documentation Impact

- [ ] No documentation changes were needed
- [x] I updated the relevant documentation

## Checklist

- [x] My change is focused and reviewable
- [x] I performed a self-review
- [ ] I added comments only where they help explain non-obvious logic
- [ ] I added or updated tests when applicable
- [x] I ran the validation listed above
- [x] I used the existing issue/PR templates where applicable

## Related Issues

Closes #N/A
